### PR TITLE
feat: add unit tests covering the current functionality

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -512,6 +512,24 @@ pytest = ">=6.2.5"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0"},
+    {file = "pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "requests"
 version = "2.32.4"
 description = "Python HTTP for Humans."
@@ -701,4 +719,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "37319861f43ccb174b46f0e57a8cae82b4065edd254a044ba24100d6ae65edf2"
+content-hash = "45e938dcfcab858c82f4caa7e5f9c8fab022469f63a28b8a95b4527efbdab342"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ mypy = "^1.16.1"
 tox = "^4.27.0"
 pytest-cov = "^6.2.1"
 types-requests = "^2.32.4.20250611"
+pytest-mock = "^3.14.1"
 
 [tool.poetry.scripts]
 pullsar = "pullsar.main:main"

--- a/src/pullsar/cli.py
+++ b/src/pullsar/cli.py
@@ -1,5 +1,5 @@
 import argparse
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Optional
 
 from pullsar.config import BaseConfig
 
@@ -15,7 +15,7 @@ class ParsedArgs(NamedTuple):
     catalog_image_list: List[str]
 
 
-def parse_arguments() -> ParsedArgs:
+def parse_arguments(argv: Optional[List[str]] = None) -> ParsedArgs:
     parser = argparse.ArgumentParser(
         description="Script for retrieving latest pull counts for all the operators "
         "and their versions defined in the input operators catalogs "
@@ -46,7 +46,7 @@ def parse_arguments() -> ParsedArgs:
         help="catalog image pullspec to render (repeatable)",
         metavar="CATALOG_IMAGE",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not (BaseConfig.LOG_DAYS_MIN <= args.log_days <= BaseConfig.LOG_DAYS_MAX):
         parser.error(

--- a/src/pullsar/cli.py
+++ b/src/pullsar/cli.py
@@ -48,6 +48,12 @@ def parse_arguments() -> ParsedArgs:
     )
     args = parser.parse_args()
 
+    if not (BaseConfig.LOG_DAYS_MIN <= args.log_days <= BaseConfig.LOG_DAYS_MAX):
+        parser.error(
+            f"argument --log-days: must be between {BaseConfig.LOG_DAYS_MIN} "
+            f"and {BaseConfig.LOG_DAYS_MAX}"
+        )
+
     return ParsedArgs(
         debug=args.debug,
         log_days=args.log_days,

--- a/src/pullsar/config.py
+++ b/src/pullsar/config.py
@@ -49,3 +49,5 @@ class BaseConfig(object):
     # destination for output rendered JSON operators catalog files
     CATALOG_JSON_FILE = "operators_catalog.json"
     LOG_DAYS_DEFAULT = 7
+    LOG_DAYS_MIN = 1
+    LOG_DAYS_MAX = 30  # Quay limit

--- a/src/pullsar/operator_bundle_model.py
+++ b/src/pullsar/operator_bundle_model.py
@@ -1,9 +1,13 @@
 from typing import Optional, Tuple, Dict
 
+ImageAttributes = Tuple[
+    Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]
+]
+
 
 def extract_image_attributes(
     image: str,
-) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]:
+) -> ImageAttributes:
     """
     Parses image pullspec for attributes Quay registry, organization, repository and image digest/tag.
 
@@ -11,7 +15,7 @@ def extract_image_attributes(
         image (str): Operator image pullspec of format: quay.io/org/repo@digest OR quay.io/org/repo:tag
 
     Returns:
-        Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]: in order,
+        ImageAttributes: tuple of 5 attributes that can be extracted from image pullspec URL, in order,
         Quay registry, organization, repository, image digest, image tag;
         attributes can be None if they were not found or the input format was unexpected.
     """

--- a/src/pullsar/operator_bundle_model.py
+++ b/src/pullsar/operator_bundle_model.py
@@ -86,12 +86,12 @@ class OperatorBundle:
 
     @property
     def org(self) -> Optional[str]:
-        """The Quay organization name of the operator bundle image."""
+        """The organization name of the operator bundle image."""
         return self._org
 
     @property
     def repo(self) -> Optional[str]:
-        """The Quay repository name of the operator bundle image."""
+        """The repository name of the operator bundle image."""
         return self._repo
 
     @property
@@ -115,9 +115,9 @@ class OperatorBundle:
 
         Returns:
             Optional[str]: path to Quay repository, e.g. org/repo
-            or None if org or repo is None.
+            or None if org or repo is None, or registry is not quay.io.
         """
-        if self.org and self.repo:
+        if self.registry == "quay.io" and self.org and self.repo:
             return f"{self.org}/{self.repo}"
 
         return None

--- a/src/pullsar/parse_operators_catalog.py
+++ b/src/pullsar/parse_operators_catalog.py
@@ -8,7 +8,7 @@ from pullsar.config import logger
 RepositoryMap = Dict[str, List[OperatorBundle]]
 
 
-def render_operator_catalog(catalog_image: str, output_file: str):
+def render_operator_catalog(catalog_image: str, output_file: str) -> bool:
     """
     Renders the OLM catalog image to a local JSON file using opm.
     Requires 'opm' to be installed and accessible in PATH,
@@ -18,6 +18,9 @@ def render_operator_catalog(catalog_image: str, output_file: str):
         catalog_image (str): Operators catalog image pullspec
         output_file (str): Name of a file to be generated, containing
         the rendered JSON catalog.
+
+    Returns:
+        bool: True if render was successful, else False
     """
     command = ["opm", "render", catalog_image, "-o", "json"]
 
@@ -30,6 +33,7 @@ def render_operator_catalog(catalog_image: str, output_file: str):
             file.write(process.stdout)
 
         logger.info(f"Successfully rendered catalog to {output_file}")
+        return True
 
     except FileNotFoundError:
         logger.error(
@@ -44,9 +48,11 @@ def render_operator_catalog(catalog_image: str, output_file: str):
         logger.debug(f"Stdout:\n{error.stdout}")
         logger.error(f"Stderr:\n{error.stderr}")
         logger.info(f"Skipping catalog {catalog_image}...")
+        return False
     except Exception as exception:
         logger.error(f"An unexpected error occurred during opm render: {exception}")
         logger.info(f"Skipping catalog {catalog_image}...")
+        return False
 
 
 def create_repository_paths_maps(

--- a/src/pullsar/update_operator_usage_stats.py
+++ b/src/pullsar/update_operator_usage_stats.py
@@ -214,7 +214,11 @@ def update_operator_usage_stats(
         being a list of OperatorBundle objects, images of which are stored in the repository.
     """
     if catalog_image:
-        render_operator_catalog(catalog_image, BaseConfig.CATALOG_JSON_FILE)
+        is_success = render_operator_catalog(
+            catalog_image, BaseConfig.CATALOG_JSON_FILE
+        )
+        if not is_success:
+            return {}
 
     repository_paths_map, repository_paths_map_missing_digests = (
         create_repository_paths_maps(catalog_json_file or BaseConfig.CATALOG_JSON_FILE)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,77 @@
+import pytest
+
+from pullsar.cli import parse_arguments
+from pullsar.config import BaseConfig
+
+
+def test_parse_arguments_defaults() -> None:
+    """Test that default values are set correctly."""
+    parsed_args = parse_arguments([])
+    assert parsed_args.debug is False
+    assert parsed_args.log_days == BaseConfig.LOG_DAYS_DEFAULT
+    assert parsed_args.catalog_json_list == []
+    assert parsed_args.catalog_image_list == []
+
+
+def test_log_days_valid_range() -> None:
+    """Test that a valid --log-days value is accepted."""
+    args_list = ["--log-days", "15"]
+    parsed_args = parse_arguments(args_list)
+    assert parsed_args.log_days == 15
+
+
+def test_log_days_invalid_above_max() -> None:
+    """Test that a --log-days value above the max raises SystemExit."""
+    invalid_days = BaseConfig.LOG_DAYS_MAX + 1
+    args_list = ["--log-days", str(invalid_days)]
+
+    with pytest.raises(SystemExit):
+        parse_arguments(args_list)
+
+
+def test_log_days_invalid_below_min() -> None:
+    """Test that a --log-days value below the min raises SystemExit."""
+    invalid_days = BaseConfig.LOG_DAYS_MIN - 1
+    args_list = ["--log-days", str(invalid_days)]
+
+    with pytest.raises(SystemExit):
+        parse_arguments(args_list)
+
+
+def test_log_days_invalid_type() -> None:
+    """Test that non-integer --log-days raises SystemExit."""
+    args_list = ["--log-days", "not-a-number"]
+
+    with pytest.raises(SystemExit):
+        parse_arguments(args_list)
+
+
+def test_mutually_exclusive_group_error() -> None:
+    """Test that argparse raises an error if both catalog types are provided."""
+    args_list = ["--catalog-json-file", "file.json", "--catalog-image", "image:latest"]
+
+    with pytest.raises(SystemExit):
+        parse_arguments(args_list)
+
+
+def test_multiple_options_at_once() -> None:
+    """Test that multiple options are parsed correctly."""
+    args_list = [
+        "--catalog-image",
+        "image:1",
+        "--catalog-image",
+        "image:2",
+        "--catalog-image",
+        "image:3",
+        "--debug",
+        "--log-days",
+        "30",
+    ]
+    parsed_args = parse_arguments(args_list)
+    image1, image2, image3 = parsed_args.catalog_image_list
+
+    assert image1 == "image:1"
+    assert image2 == "image:2"
+    assert image3 == "image:3"
+    assert parsed_args.debug is True
+    assert parsed_args.log_days == 30

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,77 +1,38 @@
 import pytest
+from typing import List
 
-from pullsar.cli import parse_arguments
+from pullsar.cli import parse_arguments, ParsedArgs
 from pullsar.config import BaseConfig
 
 
-def test_parse_arguments_defaults() -> None:
-    """Test that default values are set correctly."""
-    parsed_args = parse_arguments([])
-    assert parsed_args.debug is False
-    assert parsed_args.log_days == BaseConfig.LOG_DAYS_DEFAULT
-    assert parsed_args.catalog_json_list == []
-    assert parsed_args.catalog_image_list == []
-
-
-def test_log_days_valid_range() -> None:
-    """Test that a valid --log-days value is accepted."""
-    args_list = ["--log-days", "15"]
-    parsed_args = parse_arguments(args_list)
-    assert parsed_args.log_days == 15
-
-
-def test_log_days_invalid_above_max() -> None:
-    """Test that a --log-days value above the max raises SystemExit."""
-    invalid_days = BaseConfig.LOG_DAYS_MAX + 1
-    args_list = ["--log-days", str(invalid_days)]
-
-    with pytest.raises(SystemExit):
-        parse_arguments(args_list)
-
-
-def test_log_days_invalid_below_min() -> None:
-    """Test that a --log-days value below the min raises SystemExit."""
-    invalid_days = BaseConfig.LOG_DAYS_MIN - 1
-    args_list = ["--log-days", str(invalid_days)]
-
-    with pytest.raises(SystemExit):
-        parse_arguments(args_list)
-
-
-def test_log_days_invalid_type() -> None:
-    """Test that non-integer --log-days raises SystemExit."""
-    args_list = ["--log-days", "not-a-number"]
-
-    with pytest.raises(SystemExit):
-        parse_arguments(args_list)
-
-
-def test_mutually_exclusive_group_error() -> None:
-    """Test that argparse raises an error if both catalog types are provided."""
-    args_list = ["--catalog-json-file", "file.json", "--catalog-image", "image:latest"]
-
-    with pytest.raises(SystemExit):
-        parse_arguments(args_list)
-
-
-def test_multiple_options_at_once() -> None:
-    """Test that multiple options are parsed correctly."""
-    args_list = [
-        "--catalog-image",
-        "image:1",
-        "--catalog-image",
-        "image:2",
-        "--catalog-image",
-        "image:3",
-        "--debug",
-        "--log-days",
-        "30",
-    ]
-    parsed_args = parse_arguments(args_list)
-    image1, image2, image3 = parsed_args.catalog_image_list
-
-    assert image1 == "image:1"
-    assert image2 == "image:2"
-    assert image3 == "image:3"
-    assert parsed_args.debug is True
-    assert parsed_args.log_days == 30
+@pytest.mark.parametrize(
+    ["args_list", "expected"],
+    [
+        ([], ParsedArgs(False, BaseConfig.LOG_DAYS_DEFAULT, [], [])),
+        (["--log-days", "15"], ParsedArgs(False, 15, [], [])),
+        (["--log-days", str(BaseConfig.LOG_DAYS_MAX + 1)], None),
+        (["--log-days", str(BaseConfig.LOG_DAYS_MIN - 1)], None),
+        (["--log-days", "not-a-number"], None),
+        (["--catalog-json-file", "file.json", "--catalog-image", "image:latest"], None),
+        (
+            [
+                "--catalog-image",
+                "image:1",
+                "--catalog-image",
+                "image:2",
+                "--catalog-image",
+                "image:3",
+                "--debug",
+                "--log-days",
+                "30",
+            ],
+            ParsedArgs(True, 30, [], ["image:1", "image:2", "image:3"]),
+        ),
+    ],
+)
+def test_parse_arguments(args_list: List[str], expected: ParsedArgs | None) -> None:
+    if expected:
+        assert parse_arguments(args_list) == expected
+    else:
+        with pytest.raises(SystemExit):
+            parse_arguments(args_list)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+import json
+import pytest
+from pytest import MonkeyPatch, LogCaptureFixture
+
+from pullsar.config import load_quay_api_tokens
+
+
+def test_load_quay_api_tokens_success(monkeypatch: MonkeyPatch) -> None:
+    """Test that tokens are loaded correctly from a valid JSON environment variable."""
+    valid_json = '{"org1": "token1", "org2": "token2"}'
+    monkeypatch.setenv("QUAY_API_TOKENS_JSON", valid_json)
+
+    tokens = load_quay_api_tokens()
+
+    expected_tokens = {"org1": "token1", "org2": "token2"}
+    assert tokens == expected_tokens
+
+
+def test_load_quay_api_tokens_not_set(
+    monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+) -> None:
+    """
+    Test that an empty dict is returned and a warning is logged
+    when the environment variable is not set.
+    """
+    monkeypatch.delenv("QUAY_API_TOKENS_JSON", raising=False)
+
+    tokens = load_quay_api_tokens()
+
+    assert tokens == {}
+    assert "QUAY_API_TOKENS_JSON is undefined" in caplog.text
+
+
+def test_load_quay_api_tokens_invalid_json(
+    monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+) -> None:
+    """
+    Test that an error is logged and JSONDecodeError is raised
+    for an invalid JSON string.
+    """
+    invalid_json = '{"org1": "token1", "org2": "token2"'
+    monkeypatch.setenv("QUAY_API_TOKENS_JSON", invalid_json)
+
+    with pytest.raises(json.JSONDecodeError):
+        load_quay_api_tokens()
+
+    assert "is not a valid JSON" in caplog.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,53 @@
-import pytest
+import logging
+from pytest_mock import MockerFixture
 
-from pullsar.main import main
+from pullsar.main import main, ParsedArgs
 
 
-@pytest.mark.skip(reason="Testing of the workflow is a future task.")
-def test_main() -> None:
-    # Test the main function
-    assert main() is None
+def test_main_with_json_files_and_debug(mocker: MockerFixture) -> None:
+    """
+    Simulates running the app with two JSON files and the --debug flag.
+    """
+    mock_args = ParsedArgs(
+        debug=True,
+        log_days=7,
+        catalog_json_list=["file1.json", "file2.json"],
+        catalog_image_list=[],
+    )
+    mocker.patch("pullsar.main.parse_arguments", return_value=mock_args)
+    mocker.patch("pullsar.main.load_quay_api_tokens", return_value={})
+    mock_quay_client = mocker.patch("pullsar.main.QuayClient")
+    mock_update_stats = mocker.patch("pullsar.main.update_operator_usage_stats")
+    mock_set_level = mocker.patch("pullsar.config.logger.setLevel")
+
+    main()
+
+    mock_set_level.assert_called_once_with(logging.DEBUG)
+    mock_quay_client.assert_called_once()
+    assert mock_update_stats.call_count == 2
+    mock_update_stats.assert_any_call(mocker.ANY, 7, catalog_json_file="file1.json")
+    mock_update_stats.assert_any_call(mocker.ANY, 7, catalog_json_file="file2.json")
+
+
+def test_main_with_catalog_images(mocker: MockerFixture) -> None:
+    """
+    Simulates running the app with a catalog image and no debug flag.
+    """
+    mock_args = ParsedArgs(
+        debug=False,
+        log_days=30,
+        catalog_json_list=[],
+        catalog_image_list=["image:1.0", "image:2.0", "image:3.0"],
+    )
+    mocker.patch("pullsar.main.parse_arguments", return_value=mock_args)
+    mocker.patch("pullsar.main.load_quay_api_tokens")
+    mocker.patch("pullsar.main.QuayClient")
+    mock_update_stats = mocker.patch("pullsar.main.update_operator_usage_stats")
+    mock_set_level = mocker.patch("pullsar.config.logger.setLevel")
+
+    main()
+
+    mock_set_level.assert_not_called()
+    mock_update_stats.assert_any_call(mocker.ANY, 30, catalog_image="image:1.0")
+    mock_update_stats.assert_any_call(mocker.ANY, 30, catalog_image="image:2.0")
+    mock_update_stats.assert_any_call(mocker.ANY, 30, catalog_image="image:3.0")

--- a/tests/test_operator_bundle_model.py
+++ b/tests/test_operator_bundle_model.py
@@ -1,0 +1,124 @@
+import pytest
+
+from pullsar.operator_bundle_model import (
+    extract_image_attributes,
+    extract_tag,
+    OperatorBundle,
+)
+
+
+def test_extract_attributes_with_tag() -> None:
+    """Test parsing a standard image URL with a tag."""
+    image = "quay.io/my-org/my-repo:v1.2.3"
+    registry, org, repo, digest, tag = extract_image_attributes(image)
+    assert registry == "quay.io"
+    assert org == "my-org"
+    assert repo == "my-repo"
+    assert digest is None
+    assert tag == "v1.2.3"
+
+
+def test_extract_attributes_with_digest() -> None:
+    """Test parsing a standard image URL with a digest."""
+    image = "quay.io/my-org/my-repo@sha256:abcdef123456"
+    registry, org, repo, digest, tag = extract_image_attributes(image)
+    assert registry == "quay.io"
+    assert org == "my-org"
+    assert repo == "my-repo"
+    assert digest == "sha256:abcdef123456"
+    assert tag is None
+
+
+def test_extract_attributes_invalid_format() -> None:
+    """Test that an improperly formatted URL returns all Nones."""
+    image = "quay.io/my-repo-only"
+    result = extract_image_attributes(image)
+    assert result == (None, None, None, None, None)
+
+
+def test_extract_attributes_no_tag_or_digest() -> None:
+    """Test a URL with a repo but no identifier."""
+    image = "quay.io/my-org/my-repo"
+    registry, org, repo, digest, tag = extract_image_attributes(image)
+    assert registry == "quay.io"
+    assert org == "my-org"
+    assert repo is None
+    assert digest is None
+    assert tag is None
+
+
+def test_extract_tag_valid_name() -> None:
+    """Test extracting a version tag from a standard bundle name."""
+    name = "my-operator.v0.1.0"
+    assert extract_tag(name) == "v0.1.0"
+
+
+def test_extract_tag_no_dot() -> None:
+    """Test a name with no version, expecting None."""
+    name = "my-operator"
+    assert extract_tag(name) is None
+
+
+@pytest.fixture
+def tagged_bundle() -> OperatorBundle:
+    """A fixture for an OperatorBundle identified by a tag."""
+    return OperatorBundle(
+        name="alpha-operator.v1.0.0",
+        package="alpha-operator",
+        image="quay.io/alpha-org/alpha-repo:v1.0.0",
+    )
+
+
+@pytest.fixture
+def digested_bundle() -> OperatorBundle:
+    """A fixture for an OperatorBundle identified by a digest."""
+    return OperatorBundle(
+        name="beta-operator.v2.0.0",
+        package="beta-operator",
+        image="quay.io/beta-org/beta-repo@sha256:fake123",
+    )
+
+
+def test_bundle_initialization_with_tag(tagged_bundle: OperatorBundle) -> None:
+    """Test that properties are correctly set for a tagged bundle."""
+    assert tagged_bundle.name == "alpha-operator.v1.0.0"
+    assert tagged_bundle.package == "alpha-operator"
+    assert tagged_bundle.image == "quay.io/alpha-org/alpha-repo:v1.0.0"
+    assert tagged_bundle.registry == "quay.io"
+    assert tagged_bundle.org == "alpha-org"
+    assert tagged_bundle.repo == "alpha-repo"
+    assert tagged_bundle.tag == "v1.0.0"
+    assert tagged_bundle.digest is None
+    assert tagged_bundle.repo_path == "alpha-org/alpha-repo"
+    assert tagged_bundle.pull_count == {}
+
+
+def test_bundle_initialization_with_digest(digested_bundle: OperatorBundle) -> None:
+    """Test that properties are correctly set for a digested bundle."""
+    assert digested_bundle.name == "beta-operator.v2.0.0"
+    assert digested_bundle.package == "beta-operator"
+    assert digested_bundle.tag == "v2.0.0"
+    assert digested_bundle.digest == "sha256:fake123"
+    assert digested_bundle.repo_path == "beta-org/beta-repo"
+
+
+def test_bundle_digest_setter(tagged_bundle: OperatorBundle) -> None:
+    """Test that the digest property can be set correctly."""
+    assert tagged_bundle.digest is None
+    tagged_bundle.digest = "sha256:newdigest"
+    assert tagged_bundle.digest == "sha256:newdigest"
+
+
+def test_bundle_repo_path_none_case() -> None:
+    """Test that repo_path is None if org or repo is missing."""
+    bundle = OperatorBundle(name="invalid.v1", package="invalid", image="invalid-url")
+    assert bundle.org is None
+    assert bundle.repo is None
+    assert bundle.repo_path is None
+
+
+def test_bundle_str_method(tagged_bundle: OperatorBundle) -> None:
+    """Test that the __str__ method returns a non-empty string."""
+    assert isinstance(str(tagged_bundle), str)
+    assert "Name: alpha-operator.v1.0.0" in str(tagged_bundle)
+    assert "Package: alpha-operator" in str(tagged_bundle)

--- a/tests/test_operator_bundle_model.py
+++ b/tests/test_operator_bundle_model.py
@@ -4,47 +4,28 @@ from pullsar.operator_bundle_model import (
     extract_image_attributes,
     extract_tag,
     OperatorBundle,
+    ImageAttributes,
 )
 
 
-def test_extract_attributes_with_tag() -> None:
-    """Test parsing a standard image URL with a tag."""
-    image = "quay.io/my-org/my-repo:v1.2.3"
-    registry, org, repo, digest, tag = extract_image_attributes(image)
-    assert registry == "quay.io"
-    assert org == "my-org"
-    assert repo == "my-repo"
-    assert digest is None
-    assert tag == "v1.2.3"
-
-
-def test_extract_attributes_with_digest() -> None:
-    """Test parsing a standard image URL with a digest."""
-    image = "quay.io/my-org/my-repo@sha256:abcdef123456"
-    registry, org, repo, digest, tag = extract_image_attributes(image)
-    assert registry == "quay.io"
-    assert org == "my-org"
-    assert repo == "my-repo"
-    assert digest == "sha256:abcdef123456"
-    assert tag is None
-
-
-def test_extract_attributes_invalid_format() -> None:
-    """Test that an improperly formatted URL returns all Nones."""
-    image = "quay.io/my-repo-only"
-    result = extract_image_attributes(image)
-    assert result == (None, None, None, None, None)
-
-
-def test_extract_attributes_no_tag_or_digest() -> None:
-    """Test a URL with a repo but no identifier."""
-    image = "quay.io/my-org/my-repo"
-    registry, org, repo, digest, tag = extract_image_attributes(image)
-    assert registry == "quay.io"
-    assert org == "my-org"
-    assert repo is None
-    assert digest is None
-    assert tag is None
+@pytest.mark.parametrize(
+    ["image", "expected"],
+    [
+        (
+            "quay.io/my-org/my-repo:v1.2.3",
+            ("quay.io", "my-org", "my-repo", None, "v1.2.3"),
+        ),
+        (
+            "quay.io/my-org/my-repo@sha256:abcdef123456",
+            ("quay.io", "my-org", "my-repo", "sha256:abcdef123456", None),
+        ),
+        ("quay.io/my-repo-only", (None, None, None, None, None)),
+        ("quay.io/my-org/my-repo", ("quay.io", "my-org", None, None, None)),
+    ],
+)
+def test_extract_attributes_from_image(image: str, expected: ImageAttributes) -> None:
+    """Test extracting attributes from image pullspec URL."""
+    assert extract_image_attributes(image) == expected
 
 
 def test_extract_tag_valid_name() -> None:

--- a/tests/test_parse_operators_catalog.py
+++ b/tests/test_parse_operators_catalog.py
@@ -1,0 +1,188 @@
+import json
+import subprocess
+import pytest
+from pytest import LogCaptureFixture
+from pytest_mock import MockerFixture
+from pathlib import Path
+
+from pullsar.parse_operators_catalog import (
+    render_operator_catalog,
+    create_repository_paths_maps,
+)
+
+
+def test_render_catalog_success(mocker: MockerFixture, tmp_path: Path) -> None:
+    """
+    Test that the opm command is called correctly and its output is written to a file.
+    """
+    mock_process = mocker.Mock()
+    mock_process.stdout = '{"schema": "olm.bundle"}'
+    mock_run = mocker.patch("subprocess.run", return_value=mock_process)
+
+    output_file = tmp_path / "catalog.json"
+    catalog_image = "my-image:latest"
+
+    render_operator_catalog(catalog_image, str(output_file))
+
+    expected_command = ["opm", "render", catalog_image, "-o", "json"]
+    mock_run.assert_called_once_with(
+        expected_command, capture_output=True, text=True, check=True
+    )
+    assert output_file.read_text() == '{"schema": "olm.bundle"}'
+
+
+def test_render_catalog_opm_not_found(
+    mocker: MockerFixture, caplog: LogCaptureFixture
+) -> None:
+    """
+    Test that a FileNotFoundError is raised and logged if opm is not installed.
+    """
+    mock_run = mocker.patch("subprocess.run", side_effect=FileNotFoundError)
+
+    with pytest.raises(FileNotFoundError):
+        render_operator_catalog("my-image:latest", "output.json")
+
+    mock_run.assert_called_once()
+    assert "'opm' command not found" in caplog.text
+
+
+def test_render_catalog_opm_fails(
+    mocker: MockerFixture, caplog: LogCaptureFixture
+) -> None:
+    """
+    Test that errors from a failed opm command are logged.
+    """
+    error = subprocess.CalledProcessError(
+        returncode=1, cmd=["opm", "..."], stderr="something went wrong"
+    )
+    mocker.patch("subprocess.run", side_effect=error)
+
+    render_operator_catalog("my-image:latest", "output.json")
+
+    assert "Rendering of catalog image failed" in caplog.text
+    assert "something went wrong" in caplog.text
+
+
+def test_render_catalog_generic_exception(
+    mocker: MockerFixture, caplog: LogCaptureFixture
+) -> None:
+    """
+    Covers the generic 'except Exception' block in render_operator_catalog.
+    """
+    mocker.patch("subprocess.run", side_effect=Exception("A generic opm error"))
+
+    render_operator_catalog("my-image:latest", "output.json")
+
+    assert "An unexpected error occurred during opm render" in caplog.text
+
+
+@pytest.fixture
+def fake_jq_output() -> str:
+    """A fixture that provides sample multi-line JSON output like jq -c."""
+    bundle1 = {"name": "op-a.v1", "package": "op-a", "image": "quay.io/org-a/repo:v1"}
+    bundle2 = {"name": "op-a.v2", "package": "op-a", "image": "quay.io/org-a/repo:v2"}
+    bundle3 = {
+        "name": "op-b.v1",
+        "package": "op-b",
+        "image": "quay.io/org-b/repo@sha256:abc",
+    }
+    # bundle with registry other than quay.io should be skipped later
+    bundle4 = {"name": "op-c.v1", "package": "op-c", "image": "docker.io/org-c/repo:v1"}
+
+    return (
+        "\n".join(
+            [
+                json.dumps(bundle1),
+                json.dumps(bundle2),
+                json.dumps(bundle3),
+                json.dumps(bundle4),
+            ]
+        )
+        + "\n\n"
+    )  # empty line to skip
+
+
+def test_create_maps_success(
+    mocker: MockerFixture, fake_jq_output: str, tmp_path: Path
+) -> None:
+    """
+    Test the happy path where jq output is parsed and maps are created correctly.
+    """
+    mock_process = mocker.Mock()
+    mock_process.stdout = fake_jq_output
+    mocker.patch("subprocess.run", return_value=mock_process)
+    catalog_file = tmp_path / "catalog.json"
+
+    all_map, missing_digest_map = create_repository_paths_maps(str(catalog_file))
+
+    assert len(all_map) == 2  # two repo paths: org-a/repo and org-b/repo
+    assert len(all_map["org-a/repo"]) == 2  # two bundles for this repo
+    assert all_map["org-a/repo"][0].name == "op-a.v1"
+    assert all_map["org-a/repo"][1].name == "op-a.v2"
+    assert all_map["org-b/repo"][0].digest == "sha256:abc"
+
+    assert len(missing_digest_map) == 1
+    assert len(missing_digest_map["org-a/repo"]) == 2
+    assert "org-b/repo" not in missing_digest_map
+
+
+def test_create_maps_jq_not_found(
+    mocker: MockerFixture, caplog: LogCaptureFixture
+) -> None:
+    """
+    Test that a FileNotFoundError is raised and logged if jq is not installed.
+    """
+    mock_run = mocker.patch("subprocess.run", side_effect=FileNotFoundError)
+
+    with pytest.raises(FileNotFoundError):
+        create_repository_paths_maps("catalog.json")
+
+    mock_run.assert_called_once()
+    assert "'jq' command not found" in caplog.text
+
+
+def test_create_maps_jq_fails(mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
+    """
+    Test that the function returns empty dicts if the jq command fails.
+    """
+    error = subprocess.CalledProcessError(returncode=1, cmd=["jq", "..."])
+    mocker.patch("subprocess.run", side_effect=error)
+
+    all_map, missing_digest_map = create_repository_paths_maps("catalog.json")
+
+    assert all_map == {}
+    assert missing_digest_map == {}
+    assert "Error running jq command" in caplog.text
+
+
+def test_create_maps_malformed_json_line(
+    mocker: MockerFixture, caplog: LogCaptureFixture, tmp_path: Path
+) -> None:
+    """
+    Test that a malformed line in the jq output is skipped with a warning.
+    """
+    malformed_output = '{"name": "op-a.v1"}\nnot-json\n{"name": "op-b.v1"}'
+    mock_process = mocker.Mock()
+    mock_process.stdout = malformed_output
+    mocker.patch("subprocess.run", return_value=mock_process)
+    catalog_file = tmp_path / "catalog.json"
+
+    create_repository_paths_maps(str(catalog_file))
+
+    assert "Could not decode JSON" in caplog.text
+    assert "Problematic line content: not-json" in caplog.text
+
+
+def test_create_maps_generic_exception(
+    mocker: MockerFixture, caplog: LogCaptureFixture
+) -> None:
+    """
+    Covers the generic 'except Exception' block in create_repository_paths_maps.
+    """
+    mocker.patch("subprocess.run", side_effect=Exception("A generic jq error"))
+
+    all_map, missing_digest_map = create_repository_paths_maps("catalog.json")
+
+    assert all_map == {}
+    assert missing_digest_map == {}
+    assert "An unexpected error occurred during jq processing" in caplog.text

--- a/tests/test_parse_operators_catalog.py
+++ b/tests/test_parse_operators_catalog.py
@@ -22,12 +22,13 @@ def test_render_catalog_success(mocker: MockerFixture, tmp_path: Path) -> None:
     output_file = tmp_path / "catalog.json"
     catalog_image = "my-image:latest"
 
-    render_operator_catalog(catalog_image, str(output_file))
+    is_success = render_operator_catalog(catalog_image, str(output_file))
 
     expected_command = ["opm", "render", catalog_image, "-o", "json"]
     mock_run.assert_called_once_with(
         expected_command, capture_output=True, text=True, check=True
     )
+    assert is_success is True
     assert output_file.read_text() == '{"schema": "olm.bundle"}'
 
 
@@ -57,8 +58,9 @@ def test_render_catalog_opm_fails(
     )
     mocker.patch("subprocess.run", side_effect=error)
 
-    render_operator_catalog("my-image:latest", "output.json")
+    is_success = render_operator_catalog("my-image:latest", "output.json")
 
+    assert is_success is False
     assert "Rendering of catalog image failed" in caplog.text
     assert "something went wrong" in caplog.text
 
@@ -71,8 +73,9 @@ def test_render_catalog_generic_exception(
     """
     mocker.patch("subprocess.run", side_effect=Exception("A generic opm error"))
 
-    render_operator_catalog("my-image:latest", "output.json")
+    is_success = render_operator_catalog("my-image:latest", "output.json")
 
+    assert is_success is False
     assert "An unexpected error occurred during opm render" in caplog.text
 
 

--- a/tests/test_quay_client.py
+++ b/tests/test_quay_client.py
@@ -1,0 +1,112 @@
+import requests
+import pytest
+from pytest_mock import MockerFixture
+from pytest import LogCaptureFixture
+
+from pullsar.quay_client import QuayClient
+
+BASE_URL = "https://quay.io/api/v1"
+API_TOKENS = {"org-a": "token-a", "org-b": "token-b"}
+
+
+@pytest.fixture
+def client() -> QuayClient:
+    """Provides a QuayClient instance for testing."""
+    return QuayClient(base_url=BASE_URL, api_tokens=API_TOKENS)
+
+
+def test_extract_org() -> None:
+    """Tests the static method for extracting the organization."""
+    assert QuayClient._extract_org("my-org/my-repo") == "my-org"
+
+
+def test_token_not_defined(client: QuayClient, caplog: LogCaptureFixture) -> None:
+    """
+    Tests that an empty list is returned and an error is logged
+    if the API token for an organization is not defined.
+    """
+    repo_path = "unknown-org/repo"
+
+    results = client.get_repo_tags(repo_path)
+
+    assert results == []
+    assert "Quay API token not defined for organization 'unknown-org'" in caplog.text
+
+
+def test_request_exception(
+    client: QuayClient, mocker: MockerFixture, caplog: LogCaptureFixture
+) -> None:
+    """
+    Tests that an empty list is returned and an error is logged
+    when a request fails.
+    """
+    mocker.patch.object(
+        client.session,
+        "get",
+        side_effect=requests.exceptions.RequestException("Timeout"),
+    )
+    repo_path = "org-a/repo"
+
+    results = client.get_repo_tags(repo_path)
+
+    assert results == []
+    assert "Request error for org-a/repo: Timeout" in caplog.text
+
+
+def test_pagination_with_next_page(client: QuayClient, mocker: MockerFixture) -> None:
+    """
+    Tests the pagination logic that uses a 'next_page' token (like for /logs).
+    """
+    mock_response_page1 = mocker.Mock()
+    mock_response_page1.json.return_value = {
+        "logs": [{"id": 1}],
+        "next_page": "token123",
+    }
+
+    mock_response_page2 = mocker.Mock()
+    mock_response_page2.json.return_value = {"logs": [{"id": 2}]}
+
+    mock_get = mocker.patch.object(
+        client.session, "get", side_effect=[mock_response_page1, mock_response_page2]
+    )
+
+    results = client.get_repo_logs("org-a/repo", log_days=7)
+
+    assert len(results) == 2
+    assert results == [{"id": 1}, {"id": 2}]
+    assert mock_get.call_count == 2
+
+    second_call_args = mock_get.call_args_list[1]
+    assert second_call_args.kwargs["params"]["next_page"] == "token123"
+
+
+def test_pagination_with_has_additional(
+    client: QuayClient, mocker: MockerFixture
+) -> None:
+    """
+    Tests the pagination logic that uses a 'has_additional' flag (like for /tag).
+    """
+    mock_response_page1 = mocker.Mock()
+    mock_response_page1.json.return_value = {
+        "tags": [{"name": "v1"}],
+        "has_additional": True,
+    }
+
+    mock_response_page2 = mocker.Mock()
+    mock_response_page2.json.return_value = {
+        "tags": [{"name": "v2"}],
+        "has_additional": False,
+    }
+
+    mock_get = mocker.patch.object(
+        client.session, "get", side_effect=[mock_response_page1, mock_response_page2]
+    )
+
+    results = client.get_repo_tags("org-b/repo")
+
+    assert len(results) == 2
+    assert results == [{"name": "v1"}, {"name": "v2"}]
+    assert mock_get.call_count == 2
+
+    second_call_args = mock_get.call_args_list[1]
+    assert second_call_args.kwargs["params"]["page"] == 2

--- a/tests/test_update_operator_usage_stats.py
+++ b/tests/test_update_operator_usage_stats.py
@@ -1,0 +1,194 @@
+import pytest
+from pytest_mock import MockerFixture
+from pytest import CaptureFixture
+
+from pullsar import update_operator_usage_stats as stats
+from pullsar.operator_bundle_model import OperatorBundle
+from pullsar.quay_client import QuayClient
+
+
+@pytest.fixture
+def sample_bundles() -> list[OperatorBundle]:
+    """Provides a list of OperatorBundle objects for a single repo."""
+    b1 = OperatorBundle("op.v1", "op", "quay.io/org/repo:v1")
+    b2 = OperatorBundle("op.v2", "op", "quay.io/org/repo:v2")
+    b3 = OperatorBundle("op.v3", "op", "quay.io/org/repo@sha256:abc")
+    return [b1, b2, b3]
+
+
+def test_tag_in_tag_map() -> None:
+    """Tests the tag equivalence logic."""
+    tag_map = {
+        "v1.0": OperatorBundle("op.v1.0", "op", "img"),
+        "2.0.0": OperatorBundle("op.2.0.0", "op", "img"),
+    }
+    assert stats.tag_in_tag_map("v1.0", tag_map) == "v1.0"
+    assert stats.tag_in_tag_map("1.0", tag_map) == "v1.0"
+    assert stats.tag_in_tag_map("v1.0.0", tag_map) is None
+
+    assert stats.tag_in_tag_map("2.0.0", tag_map) == "2.0.0"
+    assert stats.tag_in_tag_map("v2.0.0", tag_map) == "2.0.0"
+
+
+def test_create_local_tag_digest_maps(sample_bundles: list[OperatorBundle]) -> None:
+    """Tests the creation of local tag and digest maps."""
+    tag_map, digest_map = stats.create_local_tag_digest_maps(sample_bundles)
+    assert len(tag_map) == 3
+    assert tag_map.get("v1") == sample_bundles[0]
+    assert tag_map.get("v2") == sample_bundles[1]
+    assert tag_map.get("v3") == sample_bundles[2]
+
+    assert len(digest_map) == 1
+    assert digest_map.get("sha256:abc") == sample_bundles[2]
+
+
+def test_extract_date() -> None:
+    """Tests the date extraction from Quay's log format."""
+    datetime_str = "Mon, 14 Jul 2025 16:23:18 -0000"
+    assert stats.extract_date(datetime_str) == "07/14/2025"
+
+
+def test_filter_pull_repo_logs() -> None:
+    """Tests that 'pull_repo' logs are filtered and simplified."""
+    quay_logs = [
+        {"kind": "push_repo", "datetime": "Mon, 14 Jul 2025 10:00:00 -0000"},
+        {
+            "kind": "pull_repo",
+            "datetime": "Tue, 15 Jul 2025 11:00:00 -0000",
+            "metadata": {"tag": "v1"},
+        },
+        {
+            "kind": "pull_repo",
+            "datetime": "Wed, 16 Jul 2025 12:00:00 -0000",
+            "metadata": {"manifest_digest": "sha256:123"},
+        },
+    ]
+    pull_logs = stats.filter_pull_repo_logs(quay_logs)
+
+    assert len(pull_logs) == 2
+    assert pull_logs[0] == {"date": "07/15/2025", "tag": "v1"}
+    assert pull_logs[1] == {"date": "07/16/2025", "digest": "sha256:123"}
+
+
+def test_update_image_digests(
+    mocker: MockerFixture, sample_bundles: list[OperatorBundle]
+) -> None:
+    """Tests that image digests are correctly updated from mocked Quay tags."""
+    mock_quay_client = mocker.Mock(spec=QuayClient)
+    mock_quay_client.get_repo_tags.return_value = [
+        {"name": "1", "manifest_digest": "sha256:digest_for_v1"},
+        {"name": "v2", "manifest_digest": "sha256:digest_for_v2"},
+    ]
+    repo_map = {"org/repo": sample_bundles}
+
+    stats.update_image_digests(mock_quay_client, repo_map)
+
+    # digests were updated
+    assert sample_bundles[0].digest == "sha256:digest_for_v1"
+    assert sample_bundles[1].digest == "sha256:digest_for_v2"
+    # set digest stayed unchanged
+    assert sample_bundles[2].digest == "sha256:abc"
+    mock_quay_client.get_repo_tags.assert_called_once_with("org/repo")
+
+
+def test_update_image_pull_counts(
+    mocker: MockerFixture, sample_bundles: list[OperatorBundle]
+) -> None:
+    """Tests that pull counts are correctly retrieved from Quay logs."""
+    mock_quay_client = mocker.Mock(spec=QuayClient)
+    quay_logs = [
+        {
+            "kind": "pull_repo",
+            "datetime": "Mon, 14 Jul 2025 10:00:00 -0000",
+            "metadata": {"tag": "v1"},
+        },
+        {
+            "kind": "pull_repo",
+            "datetime": "Mon, 14 Jul 2025 11:00:00 -0000",
+            "metadata": {"tag": "v1"},
+        },
+        {
+            "kind": "push_repo",
+            "datetime": "Mon, 14 Jul 2025 12:00:00 -0000",
+            "metadata": {"tag": "v1.1"},
+        },
+        {
+            "kind": "pull_repo",
+            "datetime": "Tue, 15 Jul 2025 09:00:00 -0000",
+            "metadata": {"manifest_digest": "sha256:abc"},
+        },
+    ]
+    mock_quay_client.get_repo_logs.return_value = quay_logs
+    repo_map = {"org/repo": sample_bundles}
+
+    stats.update_image_pull_counts(mock_quay_client, repo_map, log_days=7)
+
+    assert sample_bundles[0].pull_count == {"07/14/2025": 2}
+    assert sample_bundles[1].pull_count == {}
+    assert sample_bundles[2].pull_count == {"07/15/2025": 1}
+    mock_quay_client.get_repo_logs.assert_called_once_with("org/repo", 7)
+
+
+def test_update_image_pull_counts_no_logs(
+    mocker: MockerFixture,
+    sample_bundles: list[OperatorBundle],
+) -> None:
+    """
+    Tests that the function handles the case where no logs are returned
+    from the Quay API.
+    """
+    mock_quay_client = mocker.Mock(spec=QuayClient)
+    mock_quay_client.get_repo_logs.return_value = []
+    repo_map = {"org/repo": sample_bundles}
+
+    stats.update_image_pull_counts(mock_quay_client, repo_map, log_days=7)
+
+    for bundle in sample_bundles:
+        assert bundle.pull_count == {}
+
+
+def test_print_operator_usage_stats(
+    capsys: CaptureFixture[str], sample_bundles: list[OperatorBundle]
+) -> None:
+    """Tests that only bundles with pull counts are printed."""
+    sample_bundles[0].pull_count["07/14/2025"] = 5
+    repo_map = {"org/repo": sample_bundles}
+
+    stats.print_operator_usage_stats(repo_map)
+    captured = capsys.readouterr()
+
+    assert "op.v1" in captured.out
+    assert "op.v2" not in captured.out
+
+
+def test_update_operator_usage_stats_flow(mocker: MockerFixture) -> None:
+    """
+    Tests the main orchestration function, mocking its dependencies.
+    """
+    mock_render = mocker.patch(
+        "pullsar.update_operator_usage_stats.render_operator_catalog"
+    )
+    mock_create_maps = mocker.patch(
+        "pullsar.update_operator_usage_stats.create_repository_paths_maps",
+        return_value=({"repo": []}, {"repo": []}),
+    )
+    mock_update_digests = mocker.patch(
+        "pullsar.update_operator_usage_stats.update_image_digests"
+    )
+    mock_update_pulls = mocker.patch(
+        "pullsar.update_operator_usage_stats.update_image_pull_counts"
+    )
+    mock_print_stats = mocker.patch(
+        "pullsar.update_operator_usage_stats.print_operator_usage_stats"
+    )
+    mock_quay_client = mocker.Mock(spec=QuayClient)
+
+    stats.update_operator_usage_stats(
+        quay_client=mock_quay_client, log_days=7, catalog_image="my-image:latest"
+    )
+
+    mock_render.assert_called_once()
+    mock_create_maps.assert_called_once()
+    mock_update_digests.assert_called_once()
+    mock_update_pulls.assert_called_once()
+    mock_print_stats.assert_called_once()


### PR DESCRIPTION
Added tests for each module (added pytest-mock dependency)

Minor fixes that came up during testing:
1. Fix: restricted --log-days option to allow number of days from 1 to 30 (based on actual Quay restrictions)
2. Fix: make the script skip catalog after failed render (previously it could move on working with JSON file catalog generated in previous runs, if there was such)
3. Fix: make 'repo_path' property of OperatorBundle object return None also if the bundle's registry is different from 'quay.io', just to make sure we are processing only bundles with images on Quay. To be solved later: expected non 'quay.io' registry such as 'registry.connect.redhat.com' proxy should be translated to 'quay.io' at OperatorBundle object's creation, so it does not get affected by this restriction.