### PR TITLE
feat: resolve 'registry.connect.redhat.com' proxy URLs as 'quay.io'

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 
+      - name: Install Kerberos development libraries
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
+
       - name: Install Poetry
         uses: snok/install-poetry@v1.4.1
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,6 +25,87 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "1.17.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
+    {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be"},
+    {file = "cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c"},
+    {file = "cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"},
+    {file = "cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655"},
+    {file = "cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8"},
+    {file = "cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65"},
+    {file = "cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9"},
+    {file = "cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d"},
+    {file = "cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a"},
+    {file = "cffi-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:636062ea65bd0195bc012fea9321aca499c0504409f413dc88af450b57ffd03b"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7eac2ef9b63c79431bc4b25f1cd649d7f061a28808cbc6c47b534bd789ef964"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e221cf152cff04059d011ee126477f0d9588303eb57e88923578ace7baad17f9"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31000ec67d4221a71bd3f67df918b1f88f676f1c3b535a7eb473255fdc0b83fc"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f17be4345073b0a7b8ea599688f692ac3ef23ce28e5df79c04de519dbc4912c"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1"},
+    {file = "cffi-1.17.1-cp38-cp38-win32.whl", hash = "sha256:7596d6620d3fa590f677e9ee430df2958d2d6d6de2feeae5b20e82c00b76fbf8"},
+    {file = "cffi-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:78122be759c3f8a014ce010908ae03364d00a1f81ab5c7f4a7a5120607ea56e1"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e"},
+    {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
+    {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
+    {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
+]
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "chardet"
 version = "5.2.0"
 description = "Universal encoding detector for Python 3"
@@ -234,6 +315,79 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "cryptography"
+version = "45.0.5"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.7"
+groups = ["main"]
+files = [
+    {file = "cryptography-45.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:101ee65078f6dd3e5a028d4f19c07ffa4dd22cce6a20eaa160f8b5219911e7d8"},
+    {file = "cryptography-45.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3a264aae5f7fbb089dbc01e0242d3b67dffe3e6292e1f5182122bdf58e65215d"},
+    {file = "cryptography-45.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e74d30ec9c7cb2f404af331d5b4099a9b322a8a6b25c4632755c8757345baac5"},
+    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3af26738f2db354aafe492fb3869e955b12b2ef2e16908c8b9cb928128d42c57"},
+    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e6c00130ed423201c5bc5544c23359141660b07999ad82e34e7bb8f882bb78e0"},
+    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:dd420e577921c8c2d31289536c386aaa30140b473835e97f83bc71ea9d2baf2d"},
+    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d05a38884db2ba215218745f0781775806bde4f32e07b135348355fe8e4991d9"},
+    {file = "cryptography-45.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ad0caded895a00261a5b4aa9af828baede54638754b51955a0ac75576b831b27"},
+    {file = "cryptography-45.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9024beb59aca9d31d36fcdc1604dd9bbeed0a55bface9f1908df19178e2f116e"},
+    {file = "cryptography-45.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:91098f02ca81579c85f66df8a588c78f331ca19089763d733e34ad359f474174"},
+    {file = "cryptography-45.0.5-cp311-abi3-win32.whl", hash = "sha256:926c3ea71a6043921050eaa639137e13dbe7b4ab25800932a8498364fc1abec9"},
+    {file = "cryptography-45.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:b85980d1e345fe769cfc57c57db2b59cff5464ee0c045d52c0df087e926fbe63"},
+    {file = "cryptography-45.0.5-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:f3562c2f23c612f2e4a6964a61d942f891d29ee320edb62ff48ffb99f3de9ae8"},
+    {file = "cryptography-45.0.5-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3fcfbefc4a7f332dece7272a88e410f611e79458fab97b5efe14e54fe476f4fd"},
+    {file = "cryptography-45.0.5-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:460f8c39ba66af7db0545a8c6f2eabcbc5a5528fc1cf6c3fa9a1e44cec33385e"},
+    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9b4cf6318915dccfe218e69bbec417fdd7c7185aa7aab139a2c0beb7468c89f0"},
+    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2089cc8f70a6e454601525e5bf2779e665d7865af002a5dec8d14e561002e135"},
+    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0027d566d65a38497bc37e0dd7c2f8ceda73597d2ac9ba93810204f56f52ebc7"},
+    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:be97d3a19c16a9be00edf79dca949c8fa7eff621763666a145f9f9535a5d7f42"},
+    {file = "cryptography-45.0.5-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:7760c1c2e1a7084153a0f68fab76e754083b126a47d0117c9ed15e69e2103492"},
+    {file = "cryptography-45.0.5-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6ff8728d8d890b3dda5765276d1bc6fb099252915a2cd3aff960c4c195745dd0"},
+    {file = "cryptography-45.0.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7259038202a47fdecee7e62e0fd0b0738b6daa335354396c6ddebdbe1206af2a"},
+    {file = "cryptography-45.0.5-cp37-abi3-win32.whl", hash = "sha256:1e1da5accc0c750056c556a93c3e9cb828970206c68867712ca5805e46dc806f"},
+    {file = "cryptography-45.0.5-cp37-abi3-win_amd64.whl", hash = "sha256:90cb0a7bb35959f37e23303b7eed0a32280510030daba3f7fdfbb65defde6a97"},
+    {file = "cryptography-45.0.5-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:206210d03c1193f4e1ff681d22885181d47efa1ab3018766a7b32a7b3d6e6afd"},
+    {file = "cryptography-45.0.5-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c648025b6840fe62e57107e0a25f604db740e728bd67da4f6f060f03017d5097"},
+    {file = "cryptography-45.0.5-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b8fa8b0a35a9982a3c60ec79905ba5bb090fc0b9addcfd3dc2dd04267e45f25e"},
+    {file = "cryptography-45.0.5-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:14d96584701a887763384f3c47f0ca7c1cce322aa1c31172680eb596b890ec30"},
+    {file = "cryptography-45.0.5-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:57c816dfbd1659a367831baca4b775b2a5b43c003daf52e9d57e1d30bc2e1b0e"},
+    {file = "cryptography-45.0.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b9e38e0a83cd51e07f5a48ff9691cae95a79bea28fe4ded168a8e5c6c77e819d"},
+    {file = "cryptography-45.0.5-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8c4a6ff8a30e9e3d38ac0539e9a9e02540ab3f827a3394f8852432f6b0ea152e"},
+    {file = "cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bd4c45986472694e5121084c6ebbd112aa919a25e783b87eb95953c9573906d6"},
+    {file = "cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:982518cd64c54fcada9d7e5cf28eabd3ee76bd03ab18e08a48cad7e8b6f31b18"},
+    {file = "cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:12e55281d993a793b0e883066f590c1ae1e802e3acb67f8b442e721e475e6463"},
+    {file = "cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:5aa1e32983d4443e310f726ee4b071ab7569f58eedfdd65e9675484a4eb67bd1"},
+    {file = "cryptography-45.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:e357286c1b76403dd384d938f93c46b2b058ed4dfcdce64a770f0537ed3feb6f"},
+    {file = "cryptography-45.0.5.tar.gz", hash = "sha256:72e76caa004ab63accdf26023fccd1d087f6d90ec6048ff33ad0445abf7f605a"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.14", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs ; python_full_version >= \"3.8.0\"", "sphinx-rtd-theme (>=3.0.0) ; python_full_version >= \"3.8.0\""]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2) ; python_full_version >= \"3.8.0\""]
+pep8test = ["check-sdist ; python_full_version >= \"3.8.0\"", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==45.0.5)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "decorator"
+version = "5.2.1"
+description = "Decorators for Humans"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "sys_platform != \"win32\""
+files = [
+    {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
+    {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 description = "Distribution utilities"
@@ -296,6 +450,45 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)",
 typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
+name = "gssapi"
+version = "1.9.0"
+description = "Python GSSAPI Wrapper"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "sys_platform != \"win32\""
+files = [
+    {file = "gssapi-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:261e00ac426d840055ddb2199f4989db7e3ce70fa18b1538f53e392b4823e8f1"},
+    {file = "gssapi-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:14a1ae12fdf1e4c8889206195ba1843de09fe82587fa113112887cd5894587c6"},
+    {file = "gssapi-1.9.0-cp310-cp310-win32.whl", hash = "sha256:2a9c745255e3a810c3e8072e267b7b302de0705f8e9a0f2c5abc92fe12b9475e"},
+    {file = "gssapi-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:dfc1b4c0bfe9f539537601c9f187edc320daf488f694e50d02d0c1eb37416962"},
+    {file = "gssapi-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:67d9be5e34403e47fb5749d5a1ad4e5a85b568e6a9add1695edb4a5b879f7560"},
+    {file = "gssapi-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:11e9b92cef11da547fc8c210fa720528fd854038504103c1b15ae2a89dce5fcd"},
+    {file = "gssapi-1.9.0-cp311-cp311-win32.whl", hash = "sha256:6c5f8a549abd187687440ec0b72e5b679d043d620442b3637d31aa2766b27cbe"},
+    {file = "gssapi-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:59e1a1a9a6c5dc430dc6edfcf497f5ca00cf417015f781c9fac2e85652cd738f"},
+    {file = "gssapi-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b66a98827fbd2864bf8993677a039d7ba4a127ca0d2d9ed73e0ef4f1baa7fd7f"},
+    {file = "gssapi-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2bddd1cc0c9859c5e0fd96d4d88eb67bd498fdbba45b14cdccfe10bfd329479f"},
+    {file = "gssapi-1.9.0-cp312-cp312-win32.whl", hash = "sha256:10134db0cf01bd7d162acb445762dbcc58b5c772a613e17c46cf8ad956c4dfec"},
+    {file = "gssapi-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:e28c7d45da68b7e36ed3fb3326744bfe39649f16e8eecd7b003b082206039c76"},
+    {file = "gssapi-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cea344246935b5337e6f8a69bb6cc45619ab3a8d74a29fcb0a39fd1e5843c89c"},
+    {file = "gssapi-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a5786bd9fcf435bd0c87dc95ae99ad68cefcc2bcc80c71fef4cb0ccdfb40f1e"},
+    {file = "gssapi-1.9.0-cp313-cp313-win32.whl", hash = "sha256:c99959a9dd62358e370482f1691e936cb09adf9a69e3e10d4f6a097240e9fd28"},
+    {file = "gssapi-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a2e43f50450e81fe855888c53df70cdd385ada979db79463b38031710a12acd9"},
+    {file = "gssapi-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c0e378d62b2fc352ca0046030cda5911d808a965200f612fdd1d74501b83e98f"},
+    {file = "gssapi-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b74031c70864d04864b7406c818f41be0c1637906fb9654b06823bcc79f151dc"},
+    {file = "gssapi-1.9.0-cp38-cp38-win32.whl", hash = "sha256:f2f3a46784d8127cc7ef10d3367dedcbe82899ea296710378ccc9b7cefe96f4c"},
+    {file = "gssapi-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:a81f30cde21031e7b1f8194a3eea7285e39e551265e7744edafd06eadc1c95bc"},
+    {file = "gssapi-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cbc93fdadd5aab9bae594538b2128044b8c5cdd1424fe015a465d8a8a587411a"},
+    {file = "gssapi-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5b2a3c0a9beb895942d4b8e31f515e52c17026e55aeaa81ee0df9bbfdac76098"},
+    {file = "gssapi-1.9.0-cp39-cp39-win32.whl", hash = "sha256:060b58b455d29ab8aca74770e667dca746264bee660ac5b6a7a17476edc2c0b8"},
+    {file = "gssapi-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:11c9fe066edb0fa0785697eb0cecf2719c7ad1d9f2bf27be57b647a617bcfaa5"},
+    {file = "gssapi-1.9.0.tar.gz", hash = "sha256:f468fac8f3f5fca8f4d1ca19e3cd4d2e10bd91074e7285464b22715d13548afe"},
+]
+
+[package.dependencies]
+decorator = "*"
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -320,6 +513,30 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
+
+[[package]]
+name = "krb5"
+version = "0.7.1"
+description = "Kerberos API bindings for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "sys_platform != \"win32\""
+files = [
+    {file = "krb5-0.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cbdcd2c4514af5ca32d189bc31f30fee2ab297dcbff74a53bd82f92ad1f6e0ef"},
+    {file = "krb5-0.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:40ad837d563865946cffd65a588f24876da2809aa5ce4412de49442d7cf11d50"},
+    {file = "krb5-0.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f503ec4b44dedb6bfe49b636d5e4df89399b27a1d06218a876a37d5651c5ab3"},
+    {file = "krb5-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af6eedfe51b759a8851c41e67f7ae404c382d510b14b626ec52cca564547a7f7"},
+    {file = "krb5-0.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a075da3721b188070d801814c58652d04d3f37ccbf399dee63251f5ff27d2987"},
+    {file = "krb5-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af1932778cd462852e2a25596737cf0ae4e361f69e892b6c3ef3a29c960de3a0"},
+    {file = "krb5-0.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3c4c2c5b48f7685a281ae88aabbc7719e35e8af454ea812cf3c38759369c7aac"},
+    {file = "krb5-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7590317af8c9633e420f90d112163687dbdd8fc9c3cee6a232d6537bcb5a65c3"},
+    {file = "krb5-0.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:87a592359cc545d061de703c164be4eabb977e3e8cae1ef0d969fadc644f9df6"},
+    {file = "krb5-0.7.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9c8c1d5967a910562dbffae74bdbe8a364d78a6cecce0a429ec17776d4729e74"},
+    {file = "krb5-0.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:44045e1f8a26927229eedbf262d3e8a5f0451acb1f77c3bd23cad1dc6244e8ad"},
+    {file = "krb5-0.7.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e9b71148b8974fc032268df23643a4089677dc3d53b65167e26e1e72eaf43204"},
+    {file = "krb5-0.7.1.tar.gz", hash = "sha256:ed5f13d5031489b10d8655c0ada28a81c2391b3ecb8a08c6d739e1e5835bc450"},
 ]
 
 [[package]]
@@ -525,6 +742,19 @@ files = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -558,6 +788,28 @@ tomli = {version = ">=2.2.1", markers = "python_version < \"3.11\""}
 [package.extras]
 docs = ["furo (>=2024.8.6)", "sphinx-autodoc-typehints (>=3.2)"]
 testing = ["covdefaults (>=2.3)", "pytest (>=8.3.5)", "pytest-cov (>=6.1.1)", "pytest-mock (>=3.14)", "setuptools (>=80.3.1)"]
+
+[[package]]
+name = "pyspnego"
+version = "0.11.2"
+description = "Windows Negotiate Authentication Client and Server"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyspnego-0.11.2-py3-none-any.whl", hash = "sha256:74abc1fb51e59360eb5c5c9086e5962174f1072c7a50cf6da0bda9a4bcfdfbd4"},
+    {file = "pyspnego-0.11.2.tar.gz", hash = "sha256:994388d308fb06e4498365ce78d222bf4f3570b6df4ec95738431f61510c971b"},
+]
+
+[package.dependencies]
+cryptography = "*"
+gssapi = {version = ">=1.6.0", optional = true, markers = "sys_platform != \"win32\" and extra == \"kerberos\""}
+krb5 = {version = ">=0.3.0", optional = true, markers = "sys_platform != \"win32\" and extra == \"kerberos\""}
+sspilib = {version = ">=0.1.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+kerberos = ["gssapi (>=1.6.0) ; sys_platform != \"win32\"", "krb5 (>=0.3.0) ; sys_platform != \"win32\""]
+yaml = ["ruamel.yaml"]
 
 [[package]]
 name = "pytest"
@@ -659,6 +911,23 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "requests-kerberos"
+version = "0.15.0"
+description = "A Kerberos authentication handler for python-requests"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "requests_kerberos-0.15.0-py2.py3-none-any.whl", hash = "sha256:ba9b0980b8489c93bfb13854fd118834e576d6700bfea3745cb2e62278cd16a6"},
+    {file = "requests_kerberos-0.15.0.tar.gz", hash = "sha256:437512e424413d8113181d696e56694ffa4259eb9a5fc4e803926963864eaf4e"},
+]
+
+[package.dependencies]
+cryptography = ">=1.3"
+pyspnego = {version = "*", extras = ["kerberos"]}
+requests = ">=1.1.0"
+
+[[package]]
 name = "ruff"
 version = "0.12.1"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -684,6 +953,48 @@ files = [
     {file = "ruff-0.12.1-py3-none-win_amd64.whl", hash = "sha256:9e1123b1c033f77bd2590e4c1fe7e8ea72ef990a85d2484351d408224d603013"},
     {file = "ruff-0.12.1-py3-none-win_arm64.whl", hash = "sha256:78ad09a022c64c13cc6077707f036bab0fac8cd7088772dcd1e5be21c5002efc"},
     {file = "ruff-0.12.1.tar.gz", hash = "sha256:806bbc17f1104fd57451a98a58df35388ee3ab422e029e8f5cf30aa4af2c138c"},
+]
+
+[[package]]
+name = "sspilib"
+version = "0.3.1"
+description = "SSPI API bindings for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "sspilib-0.3.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c45860bdc4793af572d365434020ff5a1ef78c42a2fc2c7a7d8e44eacaf475b6"},
+    {file = "sspilib-0.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:62cc4de547503dec13b81a6af82b398e9ef53ea82c3535418d7d069c7a05d5cd"},
+    {file = "sspilib-0.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f782214ae2876fe4e54d1dd54638a2e0877c32d03493926f7f3adf5253cf0e3f"},
+    {file = "sspilib-0.3.1-cp310-cp310-win32.whl", hash = "sha256:d8e54aee722faed9efde96128bc56a5895889b5ed96011ad3c8e87efe8391d40"},
+    {file = "sspilib-0.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:cdaa7bd965951cc6d032555ed87a575edba959338431a6cae3fcbfc174bb6de0"},
+    {file = "sspilib-0.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:08674256a42be6ab0481cb781f4079a46afd6b3ee73ad2569badbc88e556aa4d"},
+    {file = "sspilib-0.3.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3a31991a34d1ac96e6f33981e1d368f56b6cf7863609c8ba681b9e1307721168"},
+    {file = "sspilib-0.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e1c7fb3e40a281cdd0cfa701265fb78981f88d4c55c5e267caa63649aa490fc1"},
+    {file = "sspilib-0.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f57e4384203e96ead5038fc327a695c8c268701a22c870e109ea67fbdcfd2ac0"},
+    {file = "sspilib-0.3.1-cp311-cp311-win32.whl", hash = "sha256:c4745eb177773661211d5bf1dd3ef780a1fe7fbafe1392d3fdd8a5f520ec0fec"},
+    {file = "sspilib-0.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:dfdd841bcd88af16c4f3d9f81f170b696e8ecfa18a4d16a571f755b5e0e8e43e"},
+    {file = "sspilib-0.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:a1d41eb2daf9db3d60414e87f86962db4bb4e0c517794879b0d47f1a17cc58ba"},
+    {file = "sspilib-0.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e3e5163656bd14f0cac2c0dd2c777a272af00cecdba0e98ed5ef28c7185328b0"},
+    {file = "sspilib-0.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86aef2f824db862fb25066df286d2d0d35cf7da85474893eb573870a731b6691"},
+    {file = "sspilib-0.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c6d11fd6e47ba964881c8980476354259bf0b570fa32b986697f7681b1fc5be"},
+    {file = "sspilib-0.3.1-cp312-cp312-win32.whl", hash = "sha256:429ecda4c8ee587f734bdfc1fefaa196165bbd1f1c7980e0e49c89b60a6c956e"},
+    {file = "sspilib-0.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:3355cfc5f3d5c257dbab2396d83493330ca952f9c28f3fe964193ababcc8c293"},
+    {file = "sspilib-0.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:2edc804f769dcaf0bdfcde06e0abc47763b58c79f1b7be40f805d33c7fc057fd"},
+    {file = "sspilib-0.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:89b107704bd1ab84aff76b0b36538790cdfef233d4857b8cfebf53bd43ccf49c"},
+    {file = "sspilib-0.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6c86e12b95bbe01ac89c0bd1083d01286fe3b0b4ecd63d4c03d4b39d7564a11f"},
+    {file = "sspilib-0.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dea04c7da5fef0bf2e94c9e7e0ffdf52588b706c4df63c733c60c70731f334ba"},
+    {file = "sspilib-0.3.1-cp313-cp313-win32.whl", hash = "sha256:89ccacb390b15e2e807e20b8ae7e96f4724ff1fa2f48b1ba0f7d18ccc9b0d581"},
+    {file = "sspilib-0.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:21a26264df883ff6d367af60fdeb42476c7efb1dbfc5818970ac39edec3912e2"},
+    {file = "sspilib-0.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:44b89f866e0d14c8393dbc5a49c59296dd7b83a7ca97a0f9d6bd49cc46a04498"},
+    {file = "sspilib-0.3.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:3c8914db71560cac25476a9f7c17412ccaecc441e798ad018492d2a488a1289c"},
+    {file = "sspilib-0.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:656a15406eacde8cf933ec7282094bbfa0d489db3ebfef492308f3036c843f30"},
+    {file = "sspilib-0.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bb8d4504f2c98053ac924a5e1675d21955fcb309bd7247719fd09ce22ac37db"},
+    {file = "sspilib-0.3.1-cp39-cp39-win32.whl", hash = "sha256:35168f39c6c1db9205eb02457d01175b7de32af543c7a51d657d1c12515fe422"},
+    {file = "sspilib-0.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6fa91c59af0b4e0b4e9f90908289977fe0240be63eee8b40a934abd424e9c3ba"},
+    {file = "sspilib-0.3.1-cp39-cp39-win_arm64.whl", hash = "sha256:2812930555f693d4cffa0961c5088a4094889d1863d998c59162aa867dfc6be0"},
+    {file = "sspilib-0.3.1.tar.gz", hash = "sha256:6df074ee54e3bd9c1bccc84233b1ceb846367ba1397dc52b5fae2846f373b154"},
 ]
 
 [[package]]
@@ -838,4 +1149,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "9ceef2dd567d2a1676d7c2a8e2799c2464390327ac91dfdfad77c2a217d8467a"
+content-hash = "cc904b3b9c4d106d6da3e8ef427e58c7efa49b6259468b34ac01a148fa0890f0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ requires-python = ">=3.10"
 dependencies = [
     "requests (>=2.32.4,<3.0.0)",
     "dotenv (>=0.9.9,<0.10.0)",
-    "psycopg2-binary (>=2.9.10,<3.0.0)"
+    "psycopg2-binary (>=2.9.10,<3.0.0)",
+    "requests-kerberos (>=0.15.0,<0.16.0)"
 ]
 
 [build-system]
@@ -29,6 +30,10 @@ pytest-cov = "^6.2.1"
 types-requests = "^2.32.4.20250611"
 pytest-mock = "^3.14.1"
 types-psycopg2 = "^2.9.21.20250516"
+
+[[tool.mypy.overrides]]
+module = "requests_kerberos.*"
+ignore_missing_imports = true
 
 [tool.poetry.scripts]
 pullsar = "pullsar.main:main"

--- a/src/pullsar/config.py
+++ b/src/pullsar/config.py
@@ -62,6 +62,7 @@ class BaseConfig(object):
 
     QUAY_API_TOKENS: Dict[str, str] = {}
     QUAY_API_BASE_URL = "https://quay.io/api/v1"
+    PYXIS_API_BASE_URL = "https://pyxis.engineering.redhat.com/v1"
 
     # destination for output rendered JSON operators catalog files
     CATALOG_JSON_FILE = "operators_catalog.json"

--- a/src/pullsar/operator_bundle_model.py
+++ b/src/pullsar/operator_bundle_model.py
@@ -33,14 +33,13 @@ def extract_image_attributes(
     Parses image pullspec for attributes Quay registry, organization, repository and image digest/tag.
 
     Args:
-        image (str): Operator image pullspec of format: quay.io/org/repo@digest OR quay.io/org/repo:tag
+        image (str): Operator image pullspec of format: registry/org/repo@digest OR registry/org/repo:tag
 
     Returns:
         ImageAttributes: tuple of 5 attributes that can be extracted from image pullspec URL, in order,
         Quay registry, organization, repository, image digest, image tag;
         attributes can be None if they were not found or the input format was unexpected.
     """
-    # TODO: translate registry.connect.redhat.com proxy to quay.io registry if needed
     registry, org, repo, digest, tag = (None, None, None, None, None)
     registry_org_repo = image.split("/")
 
@@ -141,13 +140,13 @@ class OperatorBundle:
 
     @property
     def repo_path(self) -> Optional[str]:
-        """Accesses path to Quay repository of the operator bundle.
+        """Accesses path to the repository of the operator bundle.
 
         Returns:
-            Optional[str]: path to Quay repository, e.g. org/repo
-            or None if org or repo is None, or registry is not quay.io.
+            Optional[str]: path to repository, e.g. org/repo
+            or None if org or repo is None.
         """
-        if self.registry == "quay.io" and self.org and self.repo:
+        if self.org and self.repo:
             return f"{self.org}/{self.repo}"
 
         return None

--- a/src/pullsar/parse_operators_catalog.py
+++ b/src/pullsar/parse_operators_catalog.py
@@ -57,25 +57,28 @@ def render_operator_catalog(catalog_image: str, output_file: str) -> bool:
 
 def create_repository_paths_maps(
     catalog_json_file: str,
-) -> Tuple[RepositoryMap, RepositoryMap]:
+) -> Tuple[RepositoryMap, RepositoryMap, RepositoryMap]:
     """
     Parses rendered JSON operators catalog and creates mappings between
-    all the Quay repository paths and lists of the operator bundle versions
+    all the repository paths and lists of the operator bundle versions
     that are tied with these repositories.
 
     Args:
         catalog_json_file (str): Rendered JSON catalog of operators.
 
     Returns:
-        Tuple[RepositoryMap, RepositoryMap]: Two dictionaries with key-value pairs,
-        key being a Quay repository path e.g. org/repo and value being a list
+        Tuple[RepositoryMap, RepositoryMap, RepositoryMap]: Three dictionaries with key-value pairs,
+        key being a repository path e.g. org/repo and value being a list
         of OperatorBundle objects, images of which are available in these repositories.
-        First dictionary contains all repositories with all of their operator bundles
-        Second dictionary contains only repositories and their operator bundles with undefined digests
-        (digests for these need to be looked up using Quay API before moving on).
+        First dictionary contains all Quay repositories with all of their operator bundles.
+        Second dictionary contains only Quay repositories and their operator bundles with undefined
+        digests (digests for these need to be looked up using Quay API before moving on).
+        Third dictionary contains all non-Quay repositories with all of their operator
+        bundles (these can be translated to equivalent Quay repositories in some cases).
     """
     repository_paths_map: RepositoryMap = {}
     repository_paths_map_missing_digest: RepositoryMap = {}
+    repository_paths_map_not_quay: RepositoryMap = {}
 
     # select all bundle objects and make the output compact (-c ... one line, one item)
     # so we can easily process the output line by line, item by item and create
@@ -104,13 +107,18 @@ def create_repository_paths_maps(
                     name=item["name"], package=item["package"], image=item["image"]
                 )
 
-                quay_repo_path = operator.repo_path
-                if quay_repo_path:
-                    repository_paths_map.setdefault(quay_repo_path, []).append(operator)
-                    if operator.digest is None:
-                        repository_paths_map_missing_digest.setdefault(
-                            quay_repo_path, []
-                        ).append(operator)
+                repo_path = operator.repo_path
+                if repo_path:
+                    if operator.registry == "quay.io":
+                        repository_paths_map.setdefault(repo_path, []).append(operator)
+                        if operator.digest is None:
+                            repository_paths_map_missing_digest.setdefault(
+                                repo_path, []
+                            ).append(operator)
+                    else:
+                        repository_paths_map_not_quay.setdefault(repo_path, []).append(
+                            operator
+                        )
             else:
                 logger.warning(
                     f"Item on line {line_num} is missing some of the attributes "
@@ -121,7 +129,11 @@ def create_repository_paths_maps(
             f"Successfully identified {len(repository_paths_map)} repository paths "
             "and a list of their operator bundles from jq output."
         )
-        return (repository_paths_map, repository_paths_map_missing_digest)
+        return (
+            repository_paths_map,
+            repository_paths_map_missing_digest,
+            repository_paths_map_not_quay,
+        )
 
     except FileNotFoundError:
         logger.error(
@@ -134,11 +146,11 @@ def create_repository_paths_maps(
         logger.debug(f"Stdout:\n{error.stdout}...")
         logger.error(f"Stderr:\n{error.stderr}")
         logger.info(f"Skipping catalog {catalog_json_file}...")
-        return ({}, {})
+        return ({}, {}, {})
 
     except Exception as exception:
         logger.error(
             f"An unexpected error occurred during jq processing or operator creation: {exception}"
         )
         logger.info(f"Skipping catalog {catalog_json_file}...")
-        return ({}, {})
+        return ({}, {}, {})

--- a/src/pullsar/parse_operators_catalog.py
+++ b/src/pullsar/parse_operators_catalog.py
@@ -56,7 +56,7 @@ def render_operator_catalog(catalog_image: str, output_file: str) -> bool:
 
 
 def create_repository_paths_maps(
-    catalog_json_file: str,
+    catalog_json_file: str, known_image_translations: Dict[str, str]
 ) -> Tuple[RepositoryMap, RepositoryMap, RepositoryMap]:
     """
     Parses rendered JSON operators catalog and creates mappings between
@@ -65,6 +65,7 @@ def create_repository_paths_maps(
 
     Args:
         catalog_json_file (str): Rendered JSON catalog of operators.
+        known_image_translations (Tuple[str, str]): mapping from non-quay image to quay image
 
     Returns:
         Tuple[RepositoryMap, RepositoryMap, RepositoryMap]: Three dictionaries with key-value pairs,
@@ -115,7 +116,16 @@ def create_repository_paths_maps(
                             repository_paths_map_missing_digest.setdefault(
                                 repo_path, []
                             ).append(operator)
-                    else:
+                    elif known_image_translations.get(operator.image):
+                        new_bundle = OperatorBundle(
+                            operator.name,
+                            operator.package,
+                            known_image_translations[operator.image],
+                        )
+                        repository_paths_map.setdefault(repo_path, []).append(
+                            new_bundle
+                        )
+                    elif operator.registry == "registry.connect.redhat.com":
                         repository_paths_map_not_quay.setdefault(repo_path, []).append(
                             operator
                         )

--- a/src/pullsar/pyxis_client.py
+++ b/src/pullsar/pyxis_client.py
@@ -1,0 +1,59 @@
+import requests
+from typing import List, Dict, Any
+from urllib.parse import quote
+
+from requests_kerberos import HTTPKerberosAuth, DISABLED
+
+from pullsar.config import logger
+
+
+class PyxisClient:
+    """A client for interacting with the Pyxis API."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
+        self.kerberos_auth = HTTPKerberosAuth(mutual_authentication=DISABLED)
+
+    def get_images_for_repository(self, repo_path: str) -> List[Dict[str, Any]]:
+        """
+        Fetches all image data for a given repository from Pyxis.
+        Handles pagination automatically.
+
+        Args:
+            repo_path (str): The repository path, e.g., "abinitio/runtime-operator-bundle"
+
+        Returns:
+            A list of all image data objects from all pages.
+        """
+        encoded_repo = quote(repo_path, safe="")
+        endpoint = f"repositories/registry/registry.connect.redhat.com/repository/{encoded_repo}/images"
+
+        all_images = []
+        page = 0
+        while True:
+            api_url = f"{self.base_url}/{endpoint}"
+            params = {"page_size": 100, "page": page}
+            logger.debug(f"Fetching Pyxis data from {api_url} with params: {params}")
+
+            try:
+                response = self.session.get(
+                    api_url, params=params, auth=self.kerberos_auth
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                images_on_page = data.get("data", [])
+                if not images_on_page:
+                    break
+
+                all_images.extend(images_on_page)
+                page += 1
+
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Pyxis API request failed for repo {repo_path}: {e}")
+                return []
+
+        logger.info(f"Found {len(all_images)} images in Pyxis for repo {repo_path}")
+        return all_images

--- a/src/pullsar/pyxis_client.py
+++ b/src/pullsar/pyxis_client.py
@@ -1,7 +1,6 @@
 import requests
 from typing import List, Dict, Any
 from urllib.parse import quote
-
 from requests_kerberos import HTTPKerberosAuth, DISABLED
 
 from pullsar.config import logger
@@ -29,12 +28,17 @@ class PyxisClient:
         """
         encoded_repo = quote(repo_path, safe="")
         endpoint = f"repositories/registry/registry.connect.redhat.com/repository/{encoded_repo}/images"
+        fields = "data.image_id,data.repositories.registry,data.repositories.repository"
 
         all_images = []
         page = 0
         while True:
             api_url = f"{self.base_url}/{endpoint}"
-            params = {"page_size": 100, "page": page}
+            params: Dict[str, str | int] = {
+                "page_size": 100,
+                "page": page,
+                "include": fields,
+            }
             logger.debug(f"Fetching Pyxis data from {api_url} with params: {params}")
 
             try:

--- a/src/pullsar/pyxis_client.py
+++ b/src/pullsar/pyxis_client.py
@@ -15,7 +15,9 @@ class PyxisClient:
         self.session.headers.update({"Accept": "application/json"})
         self.kerberos_auth = HTTPKerberosAuth(mutual_authentication=DISABLED)
 
-    def get_images_for_repository(self, repo_path: str) -> List[Dict[str, Any]]:
+    def get_images_for_repository(
+        self, registry: str, repo_path: str, include: str
+    ) -> List[Dict[str, Any]]:
         """
         Fetches all image data for a given repository from Pyxis.
         Handles pagination automatically.
@@ -27,8 +29,7 @@ class PyxisClient:
             A list of all image data objects from all pages.
         """
         encoded_repo = quote(repo_path, safe="")
-        endpoint = f"repositories/registry/registry.connect.redhat.com/repository/{encoded_repo}/images"
-        fields = "data.image_id,data.repositories.registry,data.repositories.repository"
+        endpoint = f"repositories/registry/{registry}/repository/{encoded_repo}/images"
 
         all_images = []
         page = 0
@@ -37,7 +38,7 @@ class PyxisClient:
             params: Dict[str, str | int] = {
                 "page_size": 100,
                 "page": page,
-                "include": fields,
+                "include": include,
             }
             logger.debug(f"Fetching Pyxis data from {api_url} with params: {params}")
 

--- a/src/pullsar/update_operator_usage_stats.py
+++ b/src/pullsar/update_operator_usage_stats.py
@@ -90,8 +90,15 @@ def resolve_not_quay_repositories(
     logger.info(
         f"Attempting to resolve {len(not_quay_repos_map)} non-Quay repositories via Pyxis..."
     )
+
+    target_registry = "registry.connect.redhat.com"
+    include_fields = (
+        "data.image_id,data.repositories.registry,data.repositories.repository"
+    )
     for repo_path, bundles in not_quay_repos_map.items():
-        pyxis_images = pyxis_client.get_images_for_repository(repo_path)
+        pyxis_images = pyxis_client.get_images_for_repository(
+            target_registry, repo_path, include_fields
+        )
         if not pyxis_images:
             continue
 

--- a/src/pullsar/update_operator_usage_stats.py
+++ b/src/pullsar/update_operator_usage_stats.py
@@ -223,17 +223,17 @@ def update_operator_usage_stats(
         if not is_success:
             return {}
 
-    repository_paths_map, repository_paths_map_missing_digests = (
+    quay_repos_map, no_digest_repos_map, not_quay_repos_map = (
         create_repository_paths_maps(catalog_json_file or BaseConfig.CATALOG_JSON_FILE)
     )
 
     logger.info("\nLooking up missing manifest digests if any...")
-    update_image_digests(quay_client, repository_paths_map_missing_digests)
+    update_image_digests(quay_client, no_digest_repos_map)
 
     logger.info("\nOperator bundles and their usage stats:")
-    update_image_pull_counts(quay_client, repository_paths_map, log_days)
+    update_image_pull_counts(quay_client, quay_repos_map, log_days)
 
     logger.info(f"\nOperators pulled at least once in the last {log_days} days:")
-    print_operator_usage_stats(repository_paths_map)
+    print_operator_usage_stats(quay_repos_map)
 
-    return repository_paths_map
+    return quay_repos_map

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,8 +41,12 @@ def test_main_flow_with_db_and_debug(mocker: MockerFixture) -> None:
     mock_db_instance.connect.assert_called_once()
 
     assert mock_update_stats.call_count == 2
-    mock_update_stats.assert_any_call(mocker.ANY, 7, "image:v1", None)
-    mock_update_stats.assert_any_call(mocker.ANY, 7, "image:v2", "rendered.json")
+    mock_update_stats.assert_any_call(
+        mocker.ANY, mocker.ANY, mocker.ANY, 7, "image:v1", None
+    )
+    mock_update_stats.assert_any_call(
+        mocker.ANY, mocker.ANY, mocker.ANY, 7, "image:v2", "rendered.json"
+    )
 
     assert mock_db_instance.save_operator_usage_stats.call_count == 2
 

--- a/tests/test_pyxis_client.py
+++ b/tests/test_pyxis_client.py
@@ -1,0 +1,99 @@
+import requests
+import pytest
+from pytest_mock import MockerFixture
+from pytest import LogCaptureFixture
+
+from pullsar.pyxis_client import PyxisClient
+
+BASE_URL = "https://my-fake-pyxis.com/v1"
+
+
+@pytest.fixture
+def client() -> PyxisClient:
+    """Provides a PyxisClient instance for testing."""
+    return PyxisClient(base_url=BASE_URL)
+
+
+def test_get_images_single_page(client: PyxisClient, mocker: MockerFixture) -> None:
+    """
+    Tests the happy path where the API returns a single page of data.
+    """
+    mock_response_page1 = mocker.Mock()
+    mock_response_page1.json.return_value = {"data": [{"image_id": "abc"}]}
+
+    mock_response_page2 = mocker.Mock()
+    mock_response_page2.json.return_value = {"data": []}
+
+    mock_get = mocker.patch.object(
+        client.session, "get", side_effect=[mock_response_page1, mock_response_page2]
+    )
+
+    images = client.get_images_for_repository("my-org/my-repo")
+
+    assert len(images) == 1
+    assert images[0]["image_id"] == "abc"
+
+    assert mock_get.call_count == 2
+
+    assert mock_get.call_args_list[0].kwargs["params"]["page"] == 0
+    assert mock_get.call_args_list[1].kwargs["params"]["page"] == 1
+
+
+def test_get_images_with_pagination(client: PyxisClient, mocker: MockerFixture) -> None:
+    """
+    Tests the pagination logic over multiple pages.
+    """
+    mock_response_page1 = mocker.Mock()
+    mock_response_page1.json.return_value = {"data": [{"image_id": "p1"}]}
+
+    mock_response_page2 = mocker.Mock()
+    mock_response_page2.json.return_value = {"data": [{"image_id": "p2"}]}
+
+    mock_response_page3 = mocker.Mock()
+    mock_response_page3.json.return_value = {"data": []}
+
+    mocker.patch.object(
+        client.session,
+        "get",
+        side_effect=[mock_response_page1, mock_response_page2, mock_response_page3],
+    )
+
+    images = client.get_images_for_repository("my-org/my-repo")
+
+    assert len(images) == 2
+    assert images == [{"image_id": "p1"}, {"image_id": "p2"}]
+
+
+def test_get_images_request_fails(
+    client: PyxisClient, mocker: MockerFixture, caplog: LogCaptureFixture
+) -> None:
+    """
+    Tests that an empty list is returned and an error is logged if the request fails.
+    """
+    mocker.patch.object(
+        client.session,
+        "get",
+        side_effect=requests.exceptions.RequestException("Connection error"),
+    )
+
+    images = client.get_images_for_repository("my-org/my-repo")
+
+    assert images == []
+    assert "Pyxis API request failed for repo my-org/my-repo" in caplog.text
+    assert "Connection error" in caplog.text
+
+
+def test_repository_path_encoding(client: PyxisClient, mocker: MockerFixture) -> None:
+    """
+    Tests that the repository path is correctly URL-encoded.
+    """
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"data": []}
+    mock_get = mocker.patch.object(client.session, "get", return_value=mock_response)
+
+    repo_with_slash = "my-org/my-repo"
+    client.get_images_for_repository(repo_with_slash)
+
+    expected_url = f"{BASE_URL}/repositories/registry/registry.connect.redhat.com/repository/my-org%2Fmy-repo/images"
+    called_url = mock_get.call_args.args[0]
+    assert called_url == expected_url

--- a/tests/test_pyxis_client.py
+++ b/tests/test_pyxis_client.py
@@ -28,7 +28,9 @@ def test_get_images_single_page(client: PyxisClient, mocker: MockerFixture) -> N
         client.session, "get", side_effect=[mock_response_page1, mock_response_page2]
     )
 
-    images = client.get_images_for_repository("my-org/my-repo")
+    images = client.get_images_for_repository(
+        "registry.connect.redhat.com", "my-org/my-repo", "data.image_id"
+    )
 
     assert len(images) == 1
     assert images[0]["image_id"] == "abc"
@@ -58,7 +60,9 @@ def test_get_images_with_pagination(client: PyxisClient, mocker: MockerFixture) 
         side_effect=[mock_response_page1, mock_response_page2, mock_response_page3],
     )
 
-    images = client.get_images_for_repository("my-org/my-repo")
+    images = client.get_images_for_repository(
+        "registry.connect.redhat.com", "my-org/my-repo", "data.image_id"
+    )
 
     assert len(images) == 2
     assert images == [{"image_id": "p1"}, {"image_id": "p2"}]
@@ -76,7 +80,9 @@ def test_get_images_request_fails(
         side_effect=requests.exceptions.RequestException("Connection error"),
     )
 
-    images = client.get_images_for_repository("my-org/my-repo")
+    images = client.get_images_for_repository(
+        "registry.connect.redhat.com", "my-org/my-repo", "data.image_id"
+    )
 
     assert images == []
     assert "Pyxis API request failed for repo my-org/my-repo" in caplog.text
@@ -92,7 +98,9 @@ def test_repository_path_encoding(client: PyxisClient, mocker: MockerFixture) ->
     mock_get = mocker.patch.object(client.session, "get", return_value=mock_response)
 
     repo_with_slash = "my-org/my-repo"
-    client.get_images_for_repository(repo_with_slash)
+    client.get_images_for_repository(
+        "registry.connect.redhat.com", repo_with_slash, "data.image_id"
+    )
 
     expected_url = f"{BASE_URL}/repositories/registry/registry.connect.redhat.com/repository/my-org%2Fmy-repo/images"
     called_url = mock_get.call_args.args[0]

--- a/tests/test_update_operator_usage_stats.py
+++ b/tests/test_update_operator_usage_stats.py
@@ -171,7 +171,7 @@ def test_update_operator_usage_stats_flow(mocker: MockerFixture) -> None:
     )
     mock_create_maps = mocker.patch(
         "pullsar.update_operator_usage_stats.create_repository_paths_maps",
-        return_value=({"repo": []}, {"repo": []}),
+        return_value=({"repo": []}, {"repo": []}, {"repo": []}),
     )
     mock_update_digests = mocker.patch(
         "pullsar.update_operator_usage_stats.update_image_digests"

--- a/tests/test_update_operator_usage_stats.py
+++ b/tests/test_update_operator_usage_stats.py
@@ -2,11 +2,13 @@ import pytest
 from pytest_mock import MockerFixture
 from pytest import CaptureFixture
 from datetime import date
+from typing import List
 
 from pullsar import update_operator_usage_stats as stats
 from pullsar.operator_bundle_model import OperatorBundle
 from pullsar.quay_client import QuayClient
 from pullsar.pyxis_client import PyxisClient
+from pullsar.parse_operators_catalog import RepositoryMap
 
 
 @pytest.fixture
@@ -70,6 +72,81 @@ def test_filter_pull_repo_logs() -> None:
     assert len(pull_logs) == 2
     assert pull_logs[0] == {"date": date(2025, 7, 15), "tag": "v1"}
     assert pull_logs[1] == {"date": date(2025, 7, 16), "digest": "sha256:123"}
+
+
+@pytest.fixture
+def bundles_to_translate() -> List[OperatorBundle]:
+    """Provides a sample list of OperatorBundles that need translation."""
+    bundle1 = OperatorBundle(
+        name="op-a.v1",
+        package="op-a",
+        image="registry.connect.redhat.com/connect-org-a/repo-a@sha256:digest1",
+    )
+    bundle2 = OperatorBundle(
+        name="op-b.v1",
+        package="op-b",
+        image="registry.connect.redhat.com/connect-org-b/repo-b@sha256:digest2",
+    )
+    return [bundle1, bundle2]
+
+
+def test_resolve_repositories_success_with_multiple_bundles(
+    mocker: MockerFixture, bundles_to_translate: List[OperatorBundle]
+) -> None:
+    """
+    Tests that multiple non-Quay bundles from different repositories are
+    successfully resolved and updated.
+    """
+    mock_pyxis_client = mocker.Mock(spec=PyxisClient)
+
+    fake_response1 = [
+        {
+            "image_id": "sha256:digest1",
+            "repositories": [
+                {"registry": "quay.io", "repository": "quay-org-a/repo-a"}
+            ],
+        }
+    ]
+    fake_response2 = [
+        {
+            "image_id": "sha256:digest2",
+            "repositories": [
+                {"registry": "quay.io", "repository": "quay-org-b/repo-b"}
+            ],
+        }
+    ]
+
+    mock_pyxis_client.get_images_for_repository.side_effect = [
+        fake_response1,
+        fake_response2,
+    ]
+
+    not_quay_map: RepositoryMap = {
+        "connect-org-a/repo-a": [bundles_to_translate[0]],
+        "connect-org-b/repo-b": [bundles_to_translate[1]],
+    }
+    quay_map: RepositoryMap = {}
+    known_images_map: RepositoryMap = {}
+
+    stats.resolve_not_quay_repositories(
+        mock_pyxis_client, not_quay_map, quay_map, known_images_map
+    )
+
+    assert len(quay_map) == 2
+    assert "quay-org-a/repo-a" in quay_map
+    assert "quay-org-b/repo-b" in quay_map
+
+    bundle_a = quay_map["quay-org-a/repo-a"][0]
+    assert bundle_a.name == "op-a.v1"
+    assert bundle_a.image == "quay.io/quay-org-a/repo-a@sha256:digest1"
+
+    bundle_b = quay_map["quay-org-b/repo-b"][0]
+    assert bundle_b.name == "op-b.v1"
+    assert bundle_b.image == "quay.io/quay-org-b/repo-b@sha256:digest2"
+
+    assert len(known_images_map) == 2
+    assert known_images_map[bundles_to_translate[0].image] == bundle_a.image
+    assert known_images_map[bundles_to_translate[1].image] == bundle_b.image
 
 
 def test_update_image_digests(

--- a/tests/test_update_operator_usage_stats.py
+++ b/tests/test_update_operator_usage_stats.py
@@ -6,6 +6,7 @@ from datetime import date
 from pullsar import update_operator_usage_stats as stats
 from pullsar.operator_bundle_model import OperatorBundle
 from pullsar.quay_client import QuayClient
+from pullsar.pyxis_client import PyxisClient
 
 
 @pytest.fixture
@@ -171,7 +172,7 @@ def test_update_operator_usage_stats_flow(mocker: MockerFixture) -> None:
     )
     mock_create_maps = mocker.patch(
         "pullsar.update_operator_usage_stats.create_repository_paths_maps",
-        return_value=({"repo": []}, {"repo": []}, {"repo": []}),
+        return_value=({"repo": []}, {"repo": []}, {}),
     )
     mock_update_digests = mocker.patch(
         "pullsar.update_operator_usage_stats.update_image_digests"
@@ -183,9 +184,15 @@ def test_update_operator_usage_stats_flow(mocker: MockerFixture) -> None:
         "pullsar.update_operator_usage_stats.print_operator_usage_stats"
     )
     mock_quay_client = mocker.Mock(spec=QuayClient)
+    mock_pyxis_client = mocker.Mock(spec=PyxisClient)
+    mock_pyxis_client.get_images_for_repository.return_value = {"data": []}
 
     stats.update_operator_usage_stats(
-        quay_client=mock_quay_client, log_days=7, catalog_image="my-image:latest"
+        quay_client=mock_quay_client,
+        pyxis_client=mock_pyxis_client,
+        known_image_translations={},
+        log_days=7,
+        catalog_image="my-image:latest",
     )
 
     mock_render.assert_called_once()


### PR DESCRIPTION
1. Added not_quay_repository_map to group bundles that need their image's
'registry.connect.redhat.com' proxy URL to be translated to associated 'quay.io' URL.

2. Added pyxis_client.py for Pyxis API interactions, currently for listing
images from 'registry.connect.redhat.com' registries and looking up their
unpublished 'quay.io' equivalents. This is done in resolve_not_quay_repositories().

3. Added known_image_translations to save all the resolved images from
past catalogs of the same script run. For example, if we work with
multiple same catalogs of various OCP versions, their bundles overlap
and this way we can skip resolution of already resolved images.

4. Fix tests to fit current changes and add tests for new functionality.