### PR TITLE
feat: make argparsing accept base image and resolve OCP versions dynamically

### DIFF
--- a/apps/worker/src/pullsar/cli.py
+++ b/apps/worker/src/pullsar/cli.py
@@ -1,7 +1,8 @@
 import argparse
 from typing import NamedTuple, List, Optional
 
-from pullsar.config import BaseConfig
+from pullsar.config import BaseConfig, logger
+from pullsar.pyxis_client import PyxisClientPublic
 
 
 class ParsedCatalogArg(NamedTuple):
@@ -20,6 +21,40 @@ class ParsedArgs(NamedTuple):
     debug: bool
     log_days: int
     catalogs: List[ParsedCatalogArg]
+
+
+def discover_catalog_versions(
+    base_image: str, pyxis_client: PyxisClientPublic
+) -> List[ParsedCatalogArg]:
+    """
+    Calls the public Pyxis API to find all supported catalog image paths for
+    a given base image name by fetching all indices and filtering locally.
+    """
+    logger.info(f"Discovering supported OCP versions for base image: {base_image}")
+    try:
+        indices = pyxis_client.get_operator_indices(
+            ocp_versions_range=BaseConfig.MIN_OCP_VERSION
+        )
+
+        discovered_catalogs = []
+        for index in indices:
+            org = index.get("organization")
+            path = index.get("path")
+            if path and path.startswith(base_image) and org != "deleted":
+                logger.info(f"Discovered: {path}")
+                discovered_catalogs.append(ParsedCatalogArg(image=path, json_file=None))
+
+        if not discovered_catalogs:
+            logger.warning(
+                f"No supported catalog versions found for base image: {base_image}"
+            )
+
+        discovered_catalogs.sort(key=lambda x: x.image)
+        return discovered_catalogs
+
+    except Exception as e:
+        logger.error(f"Failed to discover catalog versions from Pyxis API: {e}")
+        exit(1)
 
 
 def parse_arguments(argv: Optional[List[str]] = None) -> ParsedArgs:
@@ -42,19 +77,31 @@ def parse_arguments(argv: Optional[List[str]] = None) -> ParsedArgs:
         default=BaseConfig.LOG_DAYS_DEFAULT,
         help="number of completed past days to include logs from (default: 7)",
     )
-    parser.add_argument(
+
+    catalog_group = parser.add_mutually_exclusive_group(required=True)
+    catalog_group.add_argument(
         "--catalog-image",
         dest="catalogs",
         action="append",
         nargs="+",
         default=[],
-        required=True,
         metavar="IMAGE [RENDERED_JSON_FILE]",
         help="operators catalog, e.g. '<CATALOG_IMAGE_PULLSPEC>:<OCP_VERSION>' "
         "to be rendered with 'opm' and used in database entry (keeping track of "
         "each operator's source catalogs). To skip render, provide optional second "
         "argument, a path to a pre-rendered catalog JSON file. Option is repeatable.",
     )
+    catalog_group.add_argument(
+        "--catalog-base-image",
+        dest="catalogs_base",
+        action="append",
+        default=[],
+        help="operators catalog without specified version, e.g. '<CATALOG_IMAGE_PULLSPEC>' "
+        "to be rendered with 'opm' and used in database entry (keeping track of "
+        "each operator's source catalogs). All supported OCP versions of that catalog will"
+        "be looked up via Pyxis API and processed. Option is repeatable.",
+    )
+
     args = parser.parse_args(argv)
 
     if not (BaseConfig.LOG_DAYS_MIN <= args.log_days <= BaseConfig.LOG_DAYS_MAX):
@@ -64,18 +111,35 @@ def parse_arguments(argv: Optional[List[str]] = None) -> ParsedArgs:
         )
 
     catalog_args: List[ParsedCatalogArg] = []
-    for catalog_info in args.catalogs:
-        if len(catalog_info) == 1:
-            catalog_args.append(ParsedCatalogArg(image=catalog_info[0], json_file=None))
-        elif len(catalog_info) == 2:
-            catalog_args.append(
-                ParsedCatalogArg(image=catalog_info[0], json_file=catalog_info[1])
-            )
-        else:
-            parser.error(
-                f"argument --catalog-image: requires 1 or 2 arguments, "
-                f"but received {len(catalog_info)}"
-            )
+    if args.catalogs_base:
+        # OCP versions of catalogs resolved dynamically via Pyxis API
+        public_pyxis_client = PyxisClientPublic(
+            base_url=BaseConfig.PYXIS_PUBLIC_API_BASE_URL
+        )
+        for base_image in args.catalogs_base:
+            if ":" in base_image:
+                parser.error(
+                    "argument --catalog-base-image: invalid format, "
+                    "OCP version shall not be specified for this argument."
+                )
+            discovered = discover_catalog_versions(base_image, public_pyxis_client)
+            catalog_args.extend(discovered)
+    else:
+        # OCP versions of catalogs provided by user input
+        for catalog_info in args.catalogs:
+            if len(catalog_info) == 1:
+                catalog_args.append(
+                    ParsedCatalogArg(image=catalog_info[0], json_file=None)
+                )
+            elif len(catalog_info) == 2:
+                catalog_args.append(
+                    ParsedCatalogArg(image=catalog_info[0], json_file=catalog_info[1])
+                )
+            else:
+                parser.error(
+                    f"argument --catalog-image: requires 1 or 2 arguments, "
+                    f"but received {len(catalog_info)}"
+                )
 
     return ParsedArgs(
         dry_run=args.dry_run,

--- a/apps/worker/src/pullsar/config.py
+++ b/apps/worker/src/pullsar/config.py
@@ -63,9 +63,12 @@ class BaseConfig(object):
     QUAY_API_TOKENS: Dict[str, str] = {}
     QUAY_API_BASE_URL = "https://quay.io/api/v1"
     PYXIS_API_BASE_URL = "https://pyxis.engineering.redhat.com/v1"
+    PYXIS_PUBLIC_API_BASE_URL = "https://catalog.redhat.com/api/containers/v1/"
 
     # destination for output rendered JSON operators catalog files
     CATALOG_JSON_FILE = "operators_catalog.json"
+    # floor for dynamically resolved OCP versions via public Pyxis
+    MIN_OCP_VERSION = "4.8"
     LOG_DAYS_DEFAULT = 7
     LOG_DAYS_MIN = 1
     LOG_DAYS_MAX = 30  # Quay limit

--- a/apps/worker/src/pullsar/pyxis_client.py
+++ b/apps/worker/src/pullsar/pyxis_client.py
@@ -6,13 +6,63 @@ from requests_kerberos import HTTPKerberosAuth, DISABLED
 from pullsar.config import logger, BaseConfig
 
 
-class PyxisClient:
-    """A client for interacting with the Pyxis API."""
+class _BasePyxisClient:
+    """A base client for Pyxis API containing shared client logic."""
 
     def __init__(self, base_url: str):
         self.base_url = base_url
         self.session = requests.Session()
         self.session.headers.update({"Accept": "application/json"})
+
+    def _fetch_paginated_data(
+        self, endpoint: str, params: Dict[str, Any], auth: Any = None
+    ) -> List[Dict[str, Any]]:
+        """
+        A generic helper to handle pagination for Pyxis API endpoints.
+        It fetches all pages of data for a given endpoint and set of parameters.
+
+        Args:
+            endpoint: The API endpoint to query (e.g., "operators/indices").
+            params: A dictionary of query parameters for the request.
+            auth: The authentication handler to use (e.g., Kerberos), if any.
+
+        Returns:
+            List[Dict[str, Any]]: A list of all items fetched from all pages.
+        """
+        all_items = []
+        page = 0
+        while True:
+            full_params: Dict[str, str | int] = {
+                **params,
+                "page_size": 100,
+                "page": page,
+            }
+            api_url = f"{self.base_url}/{endpoint}"
+            logger.debug(
+                f"Fetching Pyxis data from {api_url} with params: {full_params}"
+            )
+
+            try:
+                response = self.session.get(api_url, params=full_params, auth=auth)
+                response.raise_for_status()
+                data = response.json()
+                items_on_page = data.get("data", [])
+                if not items_on_page:
+                    break
+
+                all_items.extend(items_on_page)
+                page += 1
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Pyxis API request failed for endpoint {endpoint}: {e}")
+                return []
+        return all_items
+
+
+class PyxisClient(_BasePyxisClient):
+    """A client for interacting with the Pyxis API. Uses mTLS or Kerberos authentication."""
+
+    def __init__(self, base_url: str):
+        super().__init__(base_url)
         self.auth_method = None
 
         cert_path = BaseConfig.CLIENT_CERT_PATH
@@ -34,45 +84,46 @@ class PyxisClient:
     ) -> List[Dict[str, Any]]:
         """
         Fetches all image data for a given repository from Pyxis.
-        Handles pagination automatically.
 
         Args:
-            repo_path (str): The repository path, e.g., "abinitio/runtime-operator-bundle"
+            registry (str): The image registry e.g. "registry.connect.redhat.com".
+            repo_path (str): The repository path, e.g., "abinitio/runtime-operator-bundle".
+            include (str): The fields to include in the API response.
 
         Returns:
-            A list of all image data objects from all pages.
+            List[Dict[str, Any]]: A list of all image data objects for given registry and repository path.
         """
         encoded_repo = quote(repo_path, safe="")
         endpoint = f"repositories/registry/{registry}/repository/{encoded_repo}/images"
+        params = {"include": include}
 
-        all_images = []
-        page = 0
-        while True:
-            api_url = f"{self.base_url}/{endpoint}"
-            params: Dict[str, str | int] = {
-                "page_size": 100,
-                "page": page,
-                "include": include,
-            }
-            logger.debug(f"Fetching Pyxis data from {api_url} with params: {params}")
-
-            try:
-                response = self.session.get(
-                    api_url, params=params, auth=self.auth_method
-                )
-                response.raise_for_status()
-                data = response.json()
-
-                images_on_page = data.get("data", [])
-                if not images_on_page:
-                    break
-
-                all_images.extend(images_on_page)
-                page += 1
-
-            except requests.exceptions.RequestException as e:
-                logger.error(f"Pyxis API request failed for repo {repo_path}: {e}")
-                return []
+        all_images = self._fetch_paginated_data(endpoint, params, auth=self.auth_method)
 
         logger.info(f"Found {len(all_images)} images in Pyxis for repo {repo_path}")
         return all_images
+
+
+class PyxisClientPublic(_BasePyxisClient):
+    """
+    A client for interacting with the Pyxis API with no authentication.
+    Used for discovering externally available data.
+    """
+
+    def get_operator_indices(self, ocp_versions_range: str) -> List[Dict[str, Any]]:
+        """
+        Fetches all operator indices from the public Pyxis API for a given OCP version.
+
+        Args:
+            ocp_versions_range (str): OCP version range, e.g. '4.8' means version 4.8 and above,
+                see Pyxis API endpoint operators/indices for more details on the range format.
+
+        Returns:
+            List[Dict[str, Any]]: List of all supported index data objects. Key fields include
+                'organization' - e.g. 'community-operators'
+                'path' - e.g. <CATALOG_IMAGE_NAME>:<OCP_VERSION>
+        """
+        endpoint = "operators/indices"
+        params = {"ocp_versions_range": ocp_versions_range}
+
+        all_indices = self._fetch_paginated_data(endpoint, params)
+        return all_indices

--- a/apps/worker/tests/test_pyxis_client.py
+++ b/apps/worker/tests/test_pyxis_client.py
@@ -80,12 +80,15 @@ def test_get_images_request_fails(
         side_effect=requests.exceptions.RequestException("Connection error"),
     )
 
-    images = client.get_images_for_repository(
-        "registry.connect.redhat.com", "my-org/my-repo", "data.image_id"
-    )
+    registry = "registry.connect.redhat.com"
+    repo_path = "my-org/my-repo"
+    images = client.get_images_for_repository(registry, repo_path, "data.image_id")
 
     assert images == []
-    assert "Pyxis API request failed for repo my-org/my-repo" in caplog.text
+    assert (
+        f"Pyxis API request failed for endpoint repositories/registry/{registry}/repository/"
+        in caplog.text
+    )
     assert "Connection error" in caplog.text
 
 


### PR DESCRIPTION
The OCP versions that are tracked for the community, certified and marketplace catalogs were set as a constant (from v4.12 to v4.20) and upon new version's arrival, the jobs collecting data would have to be modified regularly and manually to track also the new version/stop tracking old ones.

1. Modified argparsing to be able to handle --base-catalog-image option - a base catalog (without specified version) is passed to the script and the supported OCP versions are looked up for that base catalog via external Pyxis API.
2. Created separate PyxisClientPublic for requests that don't need any authentication (like the OCP versions lookup) and created _BasePyxisClient class to hold the logic shared between PyxisClient and PyxisClientPublic, like part of setup and pagination.